### PR TITLE
docs: launch-ready README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,12 @@ lint: golangci-lint ## Run golangci-lint linter & yamllint
 lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
 	$(GOLANGCI_LINT) run --fix
 
+##@ Demo
+
+.PHONY: demo
+demo: ## Regenerate the README demo GIF from images/demo.tape (requires vhs+ttyd+ffmpeg).
+	./hack/gen-demo-gif.sh
+
 ##@ Build
 
 .PHONY: build

--- a/README.md
+++ b/README.md
@@ -1,14 +1,146 @@
 # OttoFlow
 
+<!-- TODO: no dark-theme logo variant exists yet (images/ottoflow.png only). If one is
+     added, switch to a <picture> with prefers-color-scheme for both GitHub themes. -->
 <img align="center" src="images/ottoflow.png" alt="OttoFlow Logo">
 
-[![Kubernetes](https://img.shields.io/badge/Kubernetes-1.29+-326CE5?logo=kubernetes&logoColor=white)](https://kubernetes.io/)
-[![Go](https://img.shields.io/badge/Go-1.26+-00ADD8?logo=go&logoColor=white)](https://golang.org/)
-[![License](https://img.shields.io/badge/license-BUSL--1.1-blue.svg)](LICENSE.md)
+**Kubernetes automation that spends an LLM only where judgement is needed —
+the agent sees computed summaries, never raw cluster specs.**
 
-**Autonomous AI workflows for Kubernetes.** Define a workflow as a CRD, and OttoFlow
-runs it as a DAG that mixes deterministic CEL, live cluster queries, and LLM agents —
-with the LLM constrained to the one step that needs judgement.
+[![Release](https://img.shields.io/github/v/release/nirmata/ottoflow?include_prereleases&sort=semver)](https://github.com/nirmata/ottoflow/releases)
+[![License](https://img.shields.io/badge/license-BUSL--1.1-blue.svg)](LICENSE.md)
+[![Go](https://img.shields.io/badge/Go-1.26+-00ADD8?logo=go&logoColor=white)](https://golang.org/)
+[![Kubernetes](https://img.shields.io/badge/Kubernetes-1.29+-326CE5?logo=kubernetes&logoColor=white)](https://kubernetes.io/)
+
+Source-available under BUSL-1.1 — free for production use, converts to
+Apache-2.0 after 4 years. See [License](#license) below.
+
+## 🚀 What is OttoFlow?
+
+OttoFlow runs autonomous AI workflows on Kubernetes. You define a workflow as a
+Kubernetes CRD, and OttoFlow executes it as a DAG (directed acyclic graph) that
+mixes deterministic CEL, live cluster queries, and LLM agents — with the model
+constrained to the one step that actually needs judgement. Collection and
+publication stay deterministic; the LLM is spent only on analysis, and it sees
+computed summaries rather than raw cluster objects.
+
+## Why OttoFlow?
+
+Kubernetes agentic applications generally follow a predictable pattern. They:
+
+1. **Collect**: query cluster and workload data.
+2. **Analyze**: process and synthesize that data, and
+3. **Publish**: execute an action, or publish data or an event.
+
+Offloading this entire loop to high-level prompts or unconstrained agents with
+cluster access is an anti-pattern: it makes every run non-deterministic, widens
+the attack surface, and drives up token cost.
+
+OttoFlow codifies the `Collect → Analyze → Publish` loop into a deterministic
+execution pattern, bringing reviewable engineering practices to the AI
+orchestration layer. OttoFlow is not a general-purpose agent framework — if you
+want free-form agents, use one of those instead.
+
+## ✨ Key Features
+
+- ✅ **Declarative, Kubernetes-native workflows** — define workflows as
+  Kubernetes CRDs in YAML.
+- ✅ **DAG execution** — explicit dependency resolution with parallel step
+  batches.
+- ✅ **Multi-provider LLM support** — reusable `Agent` CRDs for OpenAI,
+  Anthropic, Azure OpenAI, Google/Gemini, or a local model.
+- ✅ **Kubernetes integration** — query resources, scrape Prometheus (PromQL),
+  react to events, and schedule via cron.
+- ✅ **CEL expressions** — full Kubernetes and
+  [Kyverno SDK CEL](https://github.com/kyverno/sdk) library support, with
+  per-workflow cost limits.
+- ✅ **Multiple step types** — Expressions, ResourceQuery, AgentRef,
+  MCPToolCall, Mutate, ForEach, and more ([full list](#step-types)).
+- ✅ **Summaries, not raw specs** — agent steps receive computed summaries,
+  never raw cluster objects.
+- ✅ **CLI with local mode** — execute workflows in-process against your
+  kubecontext, no controller or CRDs required.
+- ✅ **Retry & conditional execution** — configurable retry policies and
+  `matchConditions` gating per step.
+- ✅ **Extensive samples** — ready-to-run workflows under [`samples/`](samples/)
+  covering cost, security, and compliance.
+
+## Your first AI workflow in ~60 seconds
+
+<!-- TODO (do not merge until stable v0.1.0 is released): the Homebrew formula is
+     published only on a stable, non-prerelease tag; today only v0.1.0-rc1 exists. -->
+```sh
+brew install nirmata/tap/ottoflow
+```
+
+Start with a pure-CEL workflow — no LLM, no API key, nothing to install:
+
+```sh
+ottoflow run cluster-overview --workflow-dir samples -n ottoflow
+```
+
+This runs in-process against your current kubecontext, read-only — no
+controller, no CRDs, nothing installed in your cluster, nothing to uninstall.
+
+### Run it without cloning
+
+<!-- TODO (do not merge until the `-f` URL/stdin PR lands): verify the exact flag
+     behavior — whether `-f <url>` runs the file's workflow directly, and whether
+     `-n ottoflow` is still needed — against that PR before merge. -->
+```sh
+ottoflow run -f https://raw.githubusercontent.com/nirmata/ottoflow/main/samples/workflows/production/pod-triage.yaml
+
+# …or straight from a pipe, nothing saved to disk:
+curl -sSL https://raw.githubusercontent.com/nirmata/ottoflow/main/samples/workflows/production/pod-triage.yaml \
+  | ottoflow run -f -
+```
+
+### No API key? No problem.
+
+`pod-triage` adds an LLM step, and the sample targets a **local** model by
+default — no cloud key, and no cluster data leaves your machine:
+
+```sh
+LLAMACPP_HOST=http://127.0.0.1:11434/ \
+  ottoflow run pod-triage --workflow-dir samples -n ottoflow --model gemma3:4b
+```
+
+Point `LLAMACPP_HOST` at any llama.cpp-compatible server — llama.cpp, ollama,
+vLLM, LM Studio. It produces the transcript shown below. (Prefer a hosted model?
+Set `--provider`/`--model` and the matching API-key environment variable instead.)
+
+Agent steps need an LLM and there is no default provider: set `modelProvider` on
+the `Agent` CRD to `openai`, `anthropic`, `azure-openai`, `google`/`gemini`, or
+`local` (any llama.cpp-compatible server). API keys come from the **process
+environment** — `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`,
+`AZURE_OPENAI_API_KEY` — not from `Agent.spec.config`. In-cluster, set them on the
+agent-executor pod via `agentExecutor.env` in the Helm chart; in local mode they
+come from your shell.
+
+<!-- demo GIF: images/demo.gif — not committed yet; record it with `make demo`
+     (needs vhs+ttyd+ffmpeg and a kind cluster, see images/demo.tape). Once the
+     GIF is recorded and committed, embed it here with:
+     <img src="images/demo.gif" alt="OttoFlow's pod-triage workflow prioritizing which failing pod to fix first"> -->
+
+```
+collectPods                    ✅ Succeeded          24ms
+triagePods                     ✅ Succeeded          1.13s
+publishTriage                  ✅ Succeeded          414µs
+
+Outputs:
+  triageSummary:
+  4 pods scanned, 2 flagged unhealthy. Verdict: The crashy pod is the highest
+  priority due to its significantly higher restart count (4), indicating a
+  persistent issue requiring immediate attention.
+
+  **Next Action:** Investigate the crashy pod's underlying cause by checking
+  system logs for crash reasons and potential resource constraints.
+```
+
+_This verdict comes from a 4B local model, which latches onto the strongest
+numeric signal (restart count). A larger local model — or a hosted provider
+via `--provider` — weighs the failure modes (OOMKilled vs ImagePullBackOff)
+more explicitly._
 
 ## A workflow, and what it actually prints
 
@@ -20,7 +152,7 @@ metadata:
   namespace: ottoflow
 spec:
   steps:
-    # 1. Collect — CEL over live cluster state. No LLM.
+    # 1. Collect — deterministic CEL over live cluster state. No LLM.
     - name: collectPods
       resourceQuery:
         apiVersion: v1
@@ -28,18 +160,24 @@ spec:
         namespace: '"default"'
         outputs:
           totalPods: size(items)
-          highRestartPods: items.filter(i, has(i.status.containerStatuses) &&
-            i.status.containerStatuses.exists(c, int(c.restartCount) > 3)).map(i, i.metadata.name)
+          # podFailureSignals: one has()-guarded CEL expression producing a list with
+          # one line per unhealthy pod — restarts > 3, or a container waiting on
+          # CrashLoopBackOff / ImagePullBackOff / ErrImagePull — e.g.
+          #   "crashy: 12 restarts, last OOMKilled"
+          #   "web-broken: 0 restarts, waiting ImagePullBackOff"
+          # built from restartCount + lastState.terminated.reason / state.waiting.reason.
+          podFailureSignals: "<CEL over items — full expression in the file linked below>"
 
-    # 2. Analyze — the agent sees only that summary, never raw pod specs.
+    # 2. Analyze — the agent sees ONLY that computed list, never raw pod specs.
+    #    Its job is to prioritize which pod to fix first, not narrate.
     - name: triagePods
       dependsOn: [collectPods]
       agentRef:
         name: pod-triage-agent
         additionalPrompts:
           - >-
-            format("Cluster snapshot -- total pods: %d, high-restart pods: %v.",
-              variables.totalPods, variables.highRestartPods)
+            format("%d pods scanned, %d unhealthy. Per-pod failure signals: %v.",
+              variables.totalPods, size(variables.podFailureSignals), variables.podFailureSignals)
 
     # 3. Publish — gated on what Collect actually found.
     - name: publishTriage
@@ -49,116 +187,38 @@ spec:
           expression: variables.totalPods > 0
 ```
 
-Run it against your cluster:
+This is an excerpt — the full file is
+[`samples/workflows/production/pod-triage.yaml`](samples/workflows/production/pod-triage.yaml).
+Run it yourself with `ottoflow run pod-triage --workflow-dir samples -n ottoflow` —
+the transcript above is what it prints.
 
-```sh
-ottoflow run pod-triage --workflow-dir samples
-```
+The agent above never sees a pod spec — only the summary the previous step
+computed. That is the whole design.
 
-```
-collectPods                    ✅ Succeeded          22ms
-triagePods                     ✅ Succeeded          27.88s
-publishTriage                  ✅ Succeeded          262µs
+## Going deeper: root cause from logs
 
-Outputs:
-  triageSummary:
-  3 pods scanned, 1 flagged for high restarts. Verdict: Investigate the persistent
-  crash-loop in pod `crashy` by examining its logs and resource usage immediately
-  to determine if OOM or misconfiguration is the cause.
-```
+`pod-triage` is the 30-second story — it runs anywhere, in-process, from Pod
+status alone. When you need the *why* behind a failure,
+[`workload-troubleshooter.yaml`](samples/workflows/production/workload-troubleshooter.yaml)
+takes one failing pod, collects its events and last 200 log lines, and asks the
+agent for a root cause and remediation. It needs the in-cluster controller — CLI
+local mode can't fetch logs — so treat it as the depth story to the hero's speed
+story.
 
-The full sample is [`samples/workflows/production/pod-triage.yaml`](samples/workflows/production/pod-triage.yaml).
+## Five workflows you'll actually use
 
-## Why not just give an agent cluster access?
+All paths are under [`samples/workflows/production/`](samples/workflows/production/).
 
-Most Kubernetes AI automation follows the same shape: **collect** cluster data,
-**analyze** it, **publish** a result. Handing that whole loop to one agent with
-cluster credentials makes every run non-deterministic, widens the attack surface,
-and pays tokens to re-derive facts a query already knows.
+| Workflow | What it does | You get |
+|---|---|---|
+| [`cluster-overview.yaml`](samples/workflows/production/cluster-overview.yaml) | Pure-CEL cluster snapshot — pod phases, per-namespace CPU/memory requests and limits, health verdict. No LLM, runs anywhere. | Structured report, zero prerequisites. |
+| [`pod-triage.yaml`](samples/workflows/production/pod-triage.yaml) | Collect → Analyze → Publish; CEL extracts per-pod failure signals (restarts, OOMKilled, ImagePullBackOff), the LLM picks the single highest-priority pod and the concrete next action. | Prioritized verdict + next step. |
+| [`resource-hygiene.yaml`](samples/workflows/production/resource-hygiene.yaml) | Detects 14 categories of unused or stale resources; LLM writes the cleanup report, Prometheus gauges track it. | Prioritized markdown report + metrics. |
+| [`cost-analyzer.yaml`](samples/workflows/production/cost-analyzer.yaml) | Right-sizing from resource specs plus metrics-server/Prometheus P95 usage, per-workload savings. | Markdown report + estimated monthly $ savings. |
+| [`workload-troubleshooter.yaml`](samples/workflows/production/workload-troubleshooter.yaml) | One failing pod: events + logs → LLM root-cause. **⚠ in-cluster only** (needs pod logs; not available in CLI local mode). | Root cause + remediation. |
 
-OttoFlow keeps collection and publication deterministic — CEL, resource queries,
-explicit dependencies — and spends the model only where judgement is actually
-required. The agent in the example above never sees a pod spec, only the summary
-the previous step computed. That is the whole design.
-
-OttoFlow is not a general-purpose agent framework. If you want free-form agents,
-use one of those instead.
-
-## Quick start
-
-**Prerequisites:** a Kubernetes cluster (1.29+) and `kubectl`. For building from
-source: Go 1.26+. For the full development loop: `docker`, `kind`, `helm`, and `ko`.
-
-```sh
-make build-cli
-```
-
-### Run locally, no controller needed
-
-Local mode loads workflows from a directory and executes them in-process against
-your current kubecontext. It is the fastest way to see OttoFlow work:
-
-```sh
-./bin/ottoflow run cluster-overview --workflow-dir samples
-```
-
-`--namespace` must match the workflow's own `metadata.namespace`. Add `--input
-key=value` to pass inputs.
-
-### Run from a URL or stdin (zero clone)
-
-`-f`/`--file` runs a single manifest locally, in-process, without cloning the repo or
-using `--workflow-dir`. It accepts a file path, an http(s) URL, or `-` for stdin:
-
-```sh
-curl -sSL https://raw.githubusercontent.com/nirmata/ottoflow/main/samples/workflows/features/hello-world.yaml \
-  | ./bin/ottoflow run -f -
-
-./bin/ottoflow run -f https://raw.githubusercontent.com/nirmata/ottoflow/main/samples/workflows/production/pod-triage.yaml
-```
-
-The namespace follows the manifest's own `metadata.namespace` (defaulting to
-`"default"` when unset) — `--namespace` has no effect here. Workflows built only from
-`expressions` or agent steps need no cluster at all. A step that does need one
-(`resourceQuery`, `mutate`, or a `resource.*` CEL function) fails with a clear
-`kubernetes client not available` error instead of a stack trace when no kubeconfig is
-present. Plain `http://` URLs are rejected unless you pass `--allow-insecure-url`.
-
-### Run in-cluster
-
-```sh
-helm upgrade --install ottoflow oci://ghcr.io/nirmata/ottoflow \
-  --version 0.1.0-rc1 --namespace ottoflow --create-namespace
-
-kubectl apply -f samples/workflows/production/cluster-overview.yaml
-./bin/ottoflow run cluster-overview --namespace ottoflow
-```
-
-### Agent steps
-
-Agent steps need an LLM. Set `modelProvider` on the `Agent` CRD — there is no
-default. Supported: `openai`, `anthropic`, `azure-openai`, `google`/`gemini`, and
-`local` (any llama.cpp-compatible server: llama.cpp, ollama, vLLM, LM Studio).
-
-API keys come from the **process environment** — `OPENAI_API_KEY`,
-`ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `AZURE_OPENAI_API_KEY` — not from
-`Agent.spec.config`. In-cluster, set them on the agent-executor pod via
-`agentExecutor.env` in the Helm chart; in local mode they come from your shell.
-
-`local` reads its server address from `LLAMACPP_HOST`, so the sample above runs
-against ollama with no cloud key at all:
-
-```sh
-LLAMACPP_HOST=http://127.0.0.1:11434/ \
-  ./bin/ottoflow run pod-triage --workflow-dir samples --model llama3
-```
-
-See [`agent-openai.yaml`](samples/workflows/features/agent-openai.yaml),
-[`agent-azure-openai.yaml`](samples/workflows/features/agent-azure-openai.yaml),
-[`agent-gemini.yaml`](samples/workflows/features/agent-gemini.yaml),
-[`agent-local-llamacpp.yaml`](samples/workflows/features/agent-local-llamacpp.yaml) and
-[`agent-custom-endpoint.yaml`](samples/workflows/features/agent-custom-endpoint.yaml) for
-per-provider configuration.
+There are 80+ more workflows in [`samples/`](samples/) covering cost, security, and
+compliance automation.
 
 ## Step types
 
@@ -193,7 +253,52 @@ Catches CEL compile errors, missing `dependsOn`, and unresolvable references
 without touching the cluster. Note that it does not compile `outputs[].value`
 expressions, so it is a strong check rather than a complete one.
 
-## Documentation
+## Install in your cluster
+
+<!-- TODO (do not merge until stable v0.1.0 is released): only chart 0.1.0-rc1 exists today. -->
+```sh
+helm install ottoflow oci://ghcr.io/nirmata/ottoflow \
+  --version 0.1.0-rc1 --namespace ottoflow --create-namespace
+
+kubectl apply -R -f samples/
+ottoflow run cluster-overview -n ottoflow
+```
+
+The controller reconciles Workflows/WorkflowRuns and runs the leader-elected
+scheduler; agent steps execute via the agent-executor pod (set LLM keys via
+`agentExecutor.env` in the chart).
+
+## Supply-chain trust
+
+Release archives publish a `checksums.txt`; verify a download before running it:
+
+```sh
+sha256sum --ignore-missing -c checksums.txt
+```
+
+Every change is scanned by [CodeQL](.github/workflows/codeql.yml) and kept current
+by [Dependabot](.github/dependabot.yml), and security issues have a disclosure path
+in [SECURITY.md](SECURITY.md).
+
+<!-- TODO: cosign signatures, SBOMs, and SLSA provenance are not yet produced by the
+     release pipeline. Add them to the supply-chain story here once the release
+     workflow emits them — do not claim them until then. -->
+
+## Architecture at a glance
+
+```mermaid
+flowchart LR
+    WF[Workflow CRD] --> C[Controller]
+    C --> WR[WorkflowRun]
+    WR --> J[Runner Job]
+    J --> E[Executor]
+    E --> CEL[CEL / resourceQuery]
+    E --> AR[agentRef]
+    AR --> AE[agent-executor]
+    E --> O[Outputs]
+```
+
+## Documentation · Help · Contributing · License
 
 - [Getting started](docs/user/tasks/getting-started.md) and [installation](docs/user/tasks/installation.md)
 - [Concepts](docs/user/concepts/) — architecture and execution model
@@ -202,7 +307,8 @@ expressions, so it is a strong check rather than a complete one.
 - [Sample workflows](samples/workflows/README.md) — production use cases, feature demos, and test fixtures
 - [Developer guide](DEVELOPER.md) and [design notes](docs/dev/DESIGN.md)
 
-## Contributing
+Questions? Open a [GitHub Issue](https://github.com/nirmata/ottoflow/issues) —
+Discussions are disabled.
 
 Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for setup, style
 and the PR process, and [GOVERNANCE.md](GOVERNANCE.md) for how decisions get made.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ constrained to the one step that actually needs judgement. Collection and
 publication stay deterministic; the LLM is spent only on analysis, and it sees
 computed summaries rather than raw cluster objects.
 
-## Why OttoFlow?
+## 🔥 Why OttoFlow?
 
 Kubernetes agentic applications generally follow a predictable pattern. They:
 

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ All paths are under [`samples/workflows/production/`](samples/workflows/producti
 | [`cost-analyzer.yaml`](samples/workflows/production/cost-analyzer.yaml) | Right-sizing from resource specs plus metrics-server/Prometheus P95 usage, per-workload savings. | Markdown report + estimated monthly $ savings. |
 | [`workload-troubleshooter.yaml`](samples/workflows/production/workload-troubleshooter.yaml) | One failing pod: events + logs → LLM root-cause. **⚠ in-cluster only** (needs pod logs; not available in CLI local mode). | Root cause + remediation. |
 
-There are 80+ more workflows in [`samples/`](samples/) covering cost, security, and
+There are 70+ more workflows in [`samples/`](samples/) covering cost, security, and
 compliance automation.
 
 ## Step types
@@ -260,7 +260,7 @@ expressions, so it is a strong check rather than a complete one.
 helm install ottoflow oci://ghcr.io/nirmata/ottoflow \
   --version 0.1.0-rc1 --namespace ottoflow --create-namespace
 
-kubectl apply -R -f samples/
+kubectl apply -f samples/workflows/production/cluster-overview.yaml
 ottoflow run cluster-overview -n ottoflow
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,7 +14,7 @@ Sources for this page: [`README.md`](../README.md),
 
 - **Go** — the module targets `go 1.26.0` (`go.mod`). CI resolves its Go
   version from `go.mod` (`.github/workflows/ci.yaml`).
-- **Kubernetes cluster 1.20+** — only needed for in-cluster execution
+- **Kubernetes cluster 1.29+** — only needed for in-cluster execution
   (`README.md`, `DEVELOPER.md`). Local execution needs no cluster.
 - **`kubectl`**, **`make`**, and (for the chart) **Helm v3** — Helm v3.13.0 is
   the version pinned in CI and in the Makefile's tooling (`.github/workflows/ci.yaml`,

--- a/docs/user/tasks/getting-started.md
+++ b/docs/user/tasks/getting-started.md
@@ -4,7 +4,7 @@ This guide walks you through creating your first OttoFlow workflow.
 
 ## Prerequisites
 
-- Kubernetes cluster (1.20+)
+- Kubernetes cluster (1.29+)
 - `kubectl` configured to access your cluster
 - OttoFlow CRDs installed (see [Installation](installation.md))
 

--- a/docs/user/tasks/installation.md
+++ b/docs/user/tasks/installation.md
@@ -2,7 +2,7 @@
 
 #### Prerequisites
 
-- Kubernetes 1.20+
+- Kubernetes 1.29+
 - Helm 3.0+ (for Helm installation)
 
 #### Installing OttoFlow

--- a/hack/demo-fixture.yaml
+++ b/hack/demo-fixture.yaml
@@ -1,0 +1,56 @@
+# Demo fixture for `make demo` (applied by hack/gen-demo-gif.sh). Seeds four pods
+# so the recorded pod-triage run shows the agent PRIORITIZING across real, differing
+# signals rather than restating one fact. Two fail differently, two are healthy —
+# giving "4 pods scanned, 2 flagged unhealthy", matching the README transcript:
+#   crashy      — OOMKilled crash-looper: restartCount climbs, lastState OOMKilled
+#   web-broken  — ImagePullBackOff: bad image tag, never starts (0 restarts)
+#   healthy-web — healthy; never flagged (proves the filter excludes healthy pods)
+#   healthy-api — healthy; never flagged
+# Applied to namespace "default" because pod-triage's resourceQuery scans default.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: crashy
+  namespace: default
+spec:
+  restartPolicy: Always
+  containers:
+    - name: crashy
+      image: busybox
+      command: ["sh", "-c", "tail /dev/zero"]   # allocates unbounded memory → OOMKilled
+      resources:
+        limits: {memory: "16Mi"}
+        requests: {memory: "16Mi"}
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: web-broken
+  namespace: default
+spec:
+  restartPolicy: Always
+  containers:
+    - name: web-broken
+      image: nginx:no-such-tag-9z9z9z          # nonexistent tag → ImagePullBackOff
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: healthy-web
+  namespace: default
+spec:
+  restartPolicy: Always
+  containers:
+    - name: healthy-web
+      image: nginx:stable
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: healthy-api
+  namespace: default
+spec:
+  restartPolicy: Always
+  containers:
+    - name: healthy-api
+      image: nginx:stable

--- a/hack/gen-demo-gif.sh
+++ b/hack/gen-demo-gif.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Regenerate images/demo.gif from images/demo.tape via VHS.
+# Usage: make demo   (or: ./hack/gen-demo-gif.sh)
+#
+# Prerequisites (this script does NOT create them):
+#   - vhs                 brew install vhs   (pulls in ttyd + ffmpeg)
+#   - a throwaway cluster with an empty default namespace, e.g.
+#       kind create cluster --name ottoflow-demo
+#     (a clean default ns matters: pod-triage scans ALL pods in default, so
+#      unrelated failing pods would skew the demo)
+#   - a llama.cpp-compatible server reachable, with LLAMACPP_HOST exported, e.g.
+#       export LLAMACPP_HOST=http://127.0.0.1:11434/
+#
+# It seeds hack/demo-fixture.yaml (a crash-looping OOMKilled pod, an
+# ImagePullBackOff pod, and a healthy one), waits for the crash-looper to
+# accumulate restarts, records the GIF, then removes the fixture.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+command -v vhs >/dev/null 2>&1 || {
+  echo "error: vhs is not installed. Install it with: brew install vhs" >&2
+  exit 1
+}
+
+echo "Seeding demo failure pods into namespace 'default'..."
+kubectl apply -f hack/demo-fixture.yaml
+trap 'kubectl delete -f hack/demo-fixture.yaml --ignore-not-found >/dev/null 2>&1 || true' EXIT
+
+echo "Waiting for 'crashy' to accumulate OOMKilled restarts (>3)..."
+for _ in $(seq 1 60); do
+  rc=$(kubectl get pod crashy -n default \
+        -o jsonpath='{.status.containerStatuses[0].restartCount}' 2>/dev/null || echo 0)
+  [ "${rc:-0}" -gt 3 ] && break
+  sleep 5
+done
+
+vhs images/demo.tape

--- a/images/demo.tape
+++ b/images/demo.tape
@@ -1,0 +1,29 @@
+# demo.tape — VHS tape (https://github.com/charmbracelet/vhs) recording the
+# pod-triage hero for the README GIF (images/demo.gif).
+#
+# Regenerate with: make demo   (runs hack/gen-demo-gif.sh, which seeds
+#   hack/demo-fixture.yaml — crashy=OOMKilled, web-broken=ImagePullBackOff,
+#   healthy-web — waits for the crash-loop, records this tape, then removes it).
+#
+# Prereqs: vhs (brew install vhs), a throwaway cluster with an empty default ns
+#   (e.g. kind create cluster), a local model server, and LLAMACPP_HOST exported.
+#   The README transcript was captured with gemma3:4b — keep the model here in sync.
+
+Output images/demo.gif
+
+Set Shell "bash"
+Set FontSize 18
+Set Width 1200
+Set Height 600
+Set Theme "Dracula"
+Set Padding 20
+Set TypingSpeed 30ms
+
+Type "LLAMACPP_HOST=http://127.0.0.1:11434/ ottoflow run pod-triage --workflow-dir samples -n ottoflow --model gemma3:4b"
+Enter
+
+# collectPods (~25ms) + the agent call (~1s on gemma3:4b) + publishTriage.
+Sleep 5s
+
+# Hold on the final verdict before cutting.
+Sleep 2s

--- a/samples/workflows/production/pod-triage.yaml
+++ b/samples/workflows/production/pod-triage.yaml
@@ -1,6 +1,8 @@
 # Hero example: Collect -> Analyze -> Publish.
-# Collect (resourceQuery, no LLM) gathers pod restart counts, Analyze (agentRef) sends
-# ONLY that summary to a local LLM, Publish is gated by matchConditions on what Collect found.
+# Collect (resourceQuery, no LLM) gathers real per-pod failure signals -- restart counts,
+# what a container is currently waiting on, what it last terminated with -- entirely in CEL.
+# Analyze (agentRef) sends ONLY that computed summary to a local LLM and asks it to
+# prioritize, not narrate. Publish is gated by matchConditions on what Collect found.
 apiVersion: ottoflow.nirmata.io/v1alpha1
 kind: Agent
 metadata:
@@ -8,9 +10,11 @@ metadata:
   namespace: ottoflow
 spec:
   prompt: |
-    You are an SRE triaging pod health. You receive ONLY a cluster snapshot summary
-    (counts and names) -- never raw pod specs. In one sentence, recommend the single
-    highest-priority next action.
+    You are an SRE triaging pod health. You receive ONLY a compact list of per-pod failure
+    signals (restart counts, current waiting reason, last termination reason) -- never raw
+    pod specs or logs. Several pods may be unhealthy for different reasons. Pick the SINGLE
+    highest-priority pod to fix first, say why in one sentence, and give ONE concrete next
+    action.
   modelProvider: local
   # "local" targets a llama.cpp-compatible server (llama.cpp, ollama, vLLM, LM Studio).
   # The server address comes from the LLAMACPP_HOST env var, not spec.config:
@@ -25,31 +29,61 @@ metadata:
   namespace: ottoflow
 spec:
   steps:
-    # 1. Collect: list pods and flag high restart counts in CEL. No LLM involved.
+    # 1. Collect: list pods and compute a per-pod failure-signal summary in CEL.
+    #    No LLM involved -- this stays deterministic. A pod is flagged unhealthy if any
+    #    container has restarted more than 3 times, or is currently waiting on a known
+    #    failure reason (CrashLoopBackOff, ImagePullBackOff, ErrImagePull). Every nested
+    #    field read is has()-guarded because containerStatuses[].state/lastState are
+    #    optional oneof-style fields that may not be present yet.
     - name: collectPods
-      message: "Collect pods and flag high restart counts"
+      message: "Collect pods and summarize per-pod failure signals"
       resourceQuery:
         apiVersion: v1
         resource: Pod
         namespace: '"default"'
         outputs:
           totalPods: size(items)
-          highRestartPods: items.filter(i, has(i.status.containerStatuses) &&
-            i.status.containerStatuses.exists(c, int(c.restartCount) > 3)).map(i, i.metadata.name)
-          highRestartCount: size(items.filter(i, has(i.status.containerStatuses) &&
-            i.status.containerStatuses.exists(c, int(c.restartCount) > 3)))
+          # One string per unhealthy pod (restarts > 3, or a container waiting on a
+          # known failure reason). The count of unhealthy pods is just the size of
+          # this list, so it is not computed separately -- see size(podFailureSignals)
+          # in the steps below. Example entries:
+          #   "crashy: 12 restarts, last OOMKilled"
+          #   "web-7f: 4 restarts, waiting ImagePullBackOff"
+          # lastState.terminated.reason takes priority when present: it's the actual cause
+          # (OOMKilled, Error, ...), whereas a waiting reason like CrashLoopBackOff just
+          # describes the retry mechanism, not why the container is crashing. Pods that
+          # never got far enough to terminate (e.g. ImagePullBackOff) have no lastState, so
+          # the waiting reason is the fallback -- and there it IS the root cause.
+          podFailureSignals: |-
+            items.filter(i, has(i.status) && has(i.status.containerStatuses) &&
+              i.status.containerStatuses.exists(c, int(c.restartCount) > 3 ||
+                (has(c.state) && has(c.state.waiting) && has(c.state.waiting.reason) &&
+                  (c.state.waiting.reason == "CrashLoopBackOff" ||
+                   c.state.waiting.reason == "ImagePullBackOff" ||
+                   c.state.waiting.reason == "ErrImagePull")))
+            ).map(i,
+              i.metadata.name + ": " +
+              string(i.status.containerStatuses.map(c, int(c.restartCount)).sum()) + " restarts, " +
+              (i.status.containerStatuses.exists(c, has(c.lastState) && has(c.lastState.terminated) && has(c.lastState.terminated.reason))
+                ? "last " + i.status.containerStatuses.filter(c,
+                    has(c.lastState) && has(c.lastState.terminated) && has(c.lastState.terminated.reason))[0].lastState.terminated.reason
+                : i.status.containerStatuses.exists(c, has(c.state) && has(c.state.waiting) && has(c.state.waiting.reason))
+                  ? "waiting " + i.status.containerStatuses.filter(c,
+                      has(c.state) && has(c.state.waiting) && has(c.state.waiting.reason))[0].state.waiting.reason
+                  : "no waiting/terminated reason reported")
+            )
 
-    # 2. Analyze: hand the agent only the collected summary, never raw pod objects.
+    # 2. Analyze: hand the agent only the computed per-pod signals, never raw pod objects.
     - name: triagePods
-      message: "Ask the agent to triage the flagged pods"
+      message: "Ask the agent to prioritize the unhealthy pods"
       dependsOn:
         - collectPods
       agentRef:
         name: pod-triage-agent
         additionalPrompts:
           - >-
-            format("Cluster snapshot -- total pods: %d, pods with restarts > 3: %d, names: %v.",
-              variables.totalPods, variables.highRestartCount, variables.highRestartPods)
+            format("Cluster snapshot -- %d pods scanned, %d unhealthy. Per-pod failure signals: %v.",
+              variables.totalPods, size(variables.podFailureSignals), variables.podFailureSignals)
       outputs:
         - name: verdict
           expression: agentOutputs.result
@@ -69,8 +103,8 @@ spec:
       outputs:
         - name: summary
           expression: >-
-            format("%d pods scanned, %d flagged for high restarts. Verdict: %s",
-              variables.totalPods, variables.highRestartCount, variables.verdict)
+            format("%d pods scanned, %d flagged unhealthy. Verdict: %s",
+              variables.totalPods, size(variables.podFailureSignals), variables.verdict)
 
   outputs:
     - name: triageSummary


### PR DESCRIPTION
## Launch-ready README

Reworks the README into an install-first launch page and adds the tooling to record the demo.

### What's in it
- **Install-first quickstart** — `brew install`, a pure-CEL `cluster-overview` run needing no LLM or cluster install, then zero-clone `-f <url>`/stdin runs and a local-model `pod-triage` that keeps cluster data on your machine.
- **Intro sections** (reviewer-requested) — restored `🚀 What is OttoFlow?`, `Why OttoFlow?`, and `✨ Key Features`, placed before the quickstart.
- **Sample gallery** — the five workflows most people will actually run (`cluster-overview`, `pod-triage`, `resource-hygiene`, `cost-analyzer`, `workload-troubleshooter`), each with what it does and what you get, plus a pointer to the 70+ others under `samples/`.
- **Annotated workflow** — the `pod-triage` Collect → Analyze → Publish excerpt showing the agent only ever sees a computed summary, never a raw pod spec.
- **Supply-chain / trust** — checksum verification, CodeQL, Dependabot, and the `SECURITY.md` disclosure path.
- **Architecture diagram** — Mermaid flow from Workflow CRD through controller, runner Job, executor, and agent-executor.
- **Provider guidance** — how to set `modelProvider` and which API-key env vars agent steps read.
- **Validate section** — `ottoflow validate` so readers lint a workflow before running it.

### Demo tooling
- `make demo` target → `hack/gen-demo-gif.sh`, which seeds `hack/demo-fixture.yaml` (an OOMKilled crash-looper, an ImagePullBackOff pod, two healthy pods), waits for restarts, and records `images/demo.tape` via VHS.

### Why this is a DRAFT
Pending, and called out with in-file TODOs:
- A stable `v0.1.0` release — needed for the helm/brew pins (currently `0.1.0-rc1`) and the release badge.
- The repo's public flip — the raw `samples/...` URLs resolve only once the repo is public.
- Recording and committing `images/demo.gif` — the hero image is left as a commented placeholder until then, so nothing renders broken.

Samples validate green via `ottoflow validate --workflow-dir samples` (the `validate-samples` CI job). No internal references.
