### PR TITLE
fix(controller): close the resume loop for waitForCallback

### DIFF
--- a/api/v1alpha1/wait_for_callback.go
+++ b/api/v1alpha1/wait_for_callback.go
@@ -35,7 +35,7 @@ type WaitForCallbackStep struct {
 	Message string `json:"message,omitempty"`
 
 	// FailurePolicy determines workflow behavior when the callback timeout is exceeded.
-	// Continue: Proceed to next step (step transitions to Skipped, not Failed)
+	// Continue: proceed to the next step; the gate resumes with empty outputs (not Failed).
 	// Fail: Workflow fails (default)
 	// +kubebuilder:validation:Enum=Continue;Fail
 	// +kubebuilder:default=Fail

--- a/charts/ottoflow/crds/ottoflow.nirmata.io_workflows.yaml
+++ b/charts/ottoflow/crds/ottoflow.nirmata.io_workflows.yaml
@@ -4929,7 +4929,7 @@ spec:
                           default: Fail
                           description: |-
                             FailurePolicy determines workflow behavior when the callback timeout is exceeded.
-                            Continue: Proceed to next step (step transitions to Skipped, not Failed)
+                            Continue: proceed to the next step; the gate resumes with empty outputs (not Failed).
                             Fail: Workflow fails (default)
                           enum:
                           - Continue

--- a/config/crd/bases/ottoflow.nirmata.io_workflows.yaml
+++ b/config/crd/bases/ottoflow.nirmata.io_workflows.yaml
@@ -4929,7 +4929,7 @@ spec:
                           default: Fail
                           description: |-
                             FailurePolicy determines workflow behavior when the callback timeout is exceeded.
-                            Continue: Proceed to next step (step transitions to Skipped, not Failed)
+                            Continue: proceed to the next step; the gate resumes with empty outputs (not Failed).
                             Fail: Workflow fails (default)
                           enum:
                           - Continue

--- a/docs/user/reference/api/workflow.md
+++ b/docs/user/reference/api/workflow.md
@@ -266,7 +266,7 @@ Pauses workflow execution at this step and waits for an external callback before
 | `waitForCallback.callbackRef` | string | No | Human-readable label for the callback (used in logs and events). |
 | `waitForCallback.message` | string | No | Message shown in logs when the step pauses; can include instructions for the callback caller. |
 | `waitForCallback.outputSchema` | JSON Schema object | No | JSON Schema for callback payload validation. Required fields are enforced; missing required fields return 400. If absent, all payloads are accepted. |
-| `waitForCallback.failurePolicy` | `Fail` \| `Continue` | No | Behavior on timeout. `Fail` (default): workflow fails. `Continue`: step transitions to Skipped with empty outputs; workflow continues. |
+| `waitForCallback.failurePolicy` | `Fail` \| `Continue` | No | Behavior on timeout. `Fail` (default): workflow fails. `Continue`: on timeout the gate resumes with empty outputs and the workflow proceeds to downstream steps. |
 
 **Callback endpoint:**
 ```
@@ -310,6 +310,7 @@ steps.awaitApproval.outputs.reviewer    # "alice@example.com"
 **Constraints:**
 - Only one `waitForCallback` can be active at a time per WorkflowRun (single `pendingCallback` slot).
 - `waitForCallback` inside `forEach` is rejected at admission.
+- Safe resume across a pause requires `WorkflowRun.spec.execution.checkpointing.enabled: true`; without it, steps that ran before the gate re-execute on resume (their outputs are not preserved).
 - Token is single-use; a second callback for the same token after outputs are set returns `200 already_accepted`.
 
 **Example:**

--- a/docs/user/reference/api/workflow.md
+++ b/docs/user/reference/api/workflow.md
@@ -262,7 +262,7 @@ Pauses workflow execution at this step and waits for an external callback before
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `waitForCallback.timeout` | string | **Yes** | Maximum wait duration (e.g. `"24h"`, `"30m"`). Step fails/skips at expiry depending on `failurePolicy`. |
+| `waitForCallback.timeout` | string | **Yes** | Maximum wait duration (e.g. `"24h"`, `"30m"`). Behavior at expiry depends on `failurePolicy` (below): the step fails, or resumes with empty outputs. |
 | `waitForCallback.callbackRef` | string | No | Human-readable label for the callback (used in logs and events). |
 | `waitForCallback.message` | string | No | Message shown in logs when the step pauses; can include instructions for the callback caller. |
 | `waitForCallback.outputSchema` | JSON Schema object | No | JSON Schema for callback payload validation. Required fields are enforced; missing required fields return 400. If absent, all payloads are accepted. |

--- a/internal/workflow/controller/callback_handler_test.go
+++ b/internal/workflow/controller/callback_handler_test.go
@@ -9,6 +9,7 @@ package controller
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -22,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	ottoflowv1alpha1 "github.com/nirmata/ottoflow/api/v1alpha1"
@@ -238,6 +240,77 @@ func TestCallbackServer_InvalidJSON(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for invalid JSON, got %d", w.Code)
+	}
+}
+
+// TestCallbackServer_TerminalPhase_ValidToken_ReturnsGone is the regression test for Fix 2a: a
+// WorkflowRun can be marked terminal (e.g. by the cron Replace cancellation path) while its
+// PendingCallback is still live. Before the fix, handleCallback admitted the callback purely on
+// token + expiry and never looked at Status.Phase, so a Failed run kept a dead callback endpoint
+// that still returned 200 and patched outputs nothing would ever consume.
+func TestCallbackServer_TerminalPhase_ValidToken_ReturnsGone(t *testing.T) {
+	scheme := newCallbackTestScheme()
+	tok := validTestToken()
+	wr := newWRWithPendingCallback("run-terminal", tok, 1*time.Hour)
+	wr.Status.Phase = ottoflowv1alpha1.WorkflowRunPhaseFailed
+
+	k8s := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(wr).
+		WithObjects(wr).
+		Build()
+
+	cs := NewCallbackServer(k8s, nil, ":0")
+
+	path := fmt.Sprintf("/api/v1/workflow-runs/default/run-terminal/callback/%s", tok)
+	req := httptest.NewRequest(http.MethodPost, path, bytes.NewBufferString(`{"approved":true}`))
+	w := httptest.NewRecorder()
+
+	cs.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusGone {
+		t.Fatalf("expected 410 for terminal-phase run, got %d: %s", w.Code, w.Body.String())
+	}
+
+	updated := &ottoflowv1alpha1.WorkflowRun{}
+	if err := k8s.Get(context.Background(), client.ObjectKeyFromObject(wr), updated); err != nil {
+		t.Fatal(err)
+	}
+	if updated.Status.PendingCallback != nil && len(updated.Status.PendingCallback.Outputs.Raw) > 0 {
+		t.Error("outputs must not be patched onto a terminal-phase run")
+	}
+}
+
+// TestCallbackServer_TerminalPhase_WrongToken_ReturnsUnauthorized confirms the security ordering
+// in Fix 2a: the terminal-phase check runs AFTER token verification, so an unauthenticated caller
+// with the wrong token cannot use the response code to probe whether a run has reached a terminal
+// phase — they still get the same 401 an active run would return.
+func TestCallbackServer_TerminalPhase_WrongToken_ReturnsUnauthorized(t *testing.T) {
+	scheme := newCallbackTestScheme()
+	tok := validTestToken()
+	wr := newWRWithPendingCallback("run-terminal-wrong-token", tok, 1*time.Hour)
+	wr.Status.Phase = ottoflowv1alpha1.WorkflowRunPhaseFailed
+
+	k8s := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(wr).
+		WithObjects(wr).
+		Build()
+
+	cs := NewCallbackServer(k8s, nil, ":0")
+
+	wrongToken := "cb_" + strings.Repeat("b2c3d4e5", 8)
+	path := fmt.Sprintf("/api/v1/workflow-runs/default/run-terminal-wrong-token/callback/%s", wrongToken)
+	req := httptest.NewRequest(http.MethodPost, path, bytes.NewBufferString(`{"approved":true}`))
+	w := httptest.NewRecorder()
+
+	cs.mux.ServeHTTP(w, req)
+
+	if w.Code == http.StatusGone {
+		t.Fatalf("wrong token on a terminal-phase run must not return 410 (would leak terminal state to an unauthenticated caller), got %d", w.Code)
+	}
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for wrong token, got %d: %s", w.Code, w.Body.String())
 	}
 }
 

--- a/internal/workflow/controller/callback_server.go
+++ b/internal/workflow/controller/callback_server.go
@@ -145,6 +145,15 @@ func (cs *CallbackServer) handleCallback(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	// Terminal-phase check: only after token verification, so a caller with the wrong token
+	// can't use this response to probe whether a run has reached a terminal phase. A run can be
+	// marked terminal (e.g. cron Replace cancellation) while a PendingCallback is still live;
+	// once terminal it must never accept a callback that can no longer be consumed.
+	if runIsTerminal(wr) {
+		writeTerminalCallbackError(w)
+		return
+	}
+
 	// Expiry check
 	if time.Now().Unix() > cb.ExpiresAt {
 		writeCallbackError(w, "callback token expired", http.StatusUnauthorized)
@@ -203,11 +212,18 @@ func (cs *CallbackServer) handleCallback(w http.ResponseWriter, r *http.Request)
 		cb.TokenHash, cb.StepName, cb.ExpiresAt, cb.CreatedAt, string(outputsJSONBytes))
 
 	conflictDetected := false
+	terminalDetected := false
 	patchErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		// Re-fetch to get latest resourceVersion for optimistic concurrency
 		fresh := &ottoflowv1alpha1.WorkflowRun{}
 		if err := cs.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, fresh); err != nil {
 			return err
+		}
+		// Safety: the run may have been marked terminal (e.g. cron Replace cancellation)
+		// between the admission check above and this re-fetch.
+		if runIsTerminal(fresh) {
+			terminalDetected = true
+			return nil
 		}
 		// Safety: another callback may have already written outputs
 		if fresh.Status.PendingCallback != nil && len(fresh.Status.PendingCallback.Outputs.Raw) > 0 {
@@ -216,6 +232,11 @@ func (cs *CallbackServer) handleCallback(w http.ResponseWriter, r *http.Request)
 		}
 		return cs.client.Status().Patch(ctx, fresh, client.RawPatch(types.MergePatchType, []byte(patchStr)))
 	})
+
+	if terminalDetected {
+		writeTerminalCallbackError(w)
+		return
+	}
 
 	if conflictDetected {
 		// Another concurrent callback already set outputs — idempotent accept
@@ -363,4 +384,17 @@ func writeCallbackError(w http.ResponseWriter, msg string, code int) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
 	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}
+
+// runIsTerminal reports whether wr has reached a terminal phase (Succeeded or Failed), at which
+// point it must never accept a callback that can no longer be consumed.
+func runIsTerminal(wr *ottoflowv1alpha1.WorkflowRun) bool {
+	return wr.Status.Phase == ottoflowv1alpha1.WorkflowRunPhaseSucceeded || wr.Status.Phase == ottoflowv1alpha1.WorkflowRunPhaseFailed
+}
+
+// writeTerminalCallbackError writes the 410 Gone response for a callback rejected because the
+// WorkflowRun has reached a terminal phase. Shared by the admission check and the retry-loop
+// re-check so both surfaces stay in sync.
+func writeTerminalCallbackError(w http.ResponseWriter) {
+	writeCallbackError(w, "workflow run has reached a terminal phase; no longer accepting callbacks", http.StatusGone)
 }

--- a/internal/workflow/controller/controller_unit_test.go
+++ b/internal/workflow/controller/controller_unit_test.go
@@ -23,6 +23,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -2103,6 +2104,268 @@ func TestGetReferencedWorkflow_PrimaryLookupSucceeds(t *testing.T) {
 	}
 	if gotNs != "ottoflow" {
 		t.Errorf("expected resolved namespace ottoflow (primary), got %q", gotNs)
+	}
+}
+
+// --- reconcilePendingCallback (waitForCallback timeout / resume) tests ---
+
+// buildCallbackWorkflowAndRun builds a minimal Workflow with a single waitForCallback step named
+// "gate" and a WorkflowRun already parked on that step with an EXPIRED PendingCallback, ready to
+// exercise the timeout branch of reconcilePendingCallback via a plain Reconcile call.
+func buildCallbackWorkflowAndRun(wfName, runName, failurePolicy string) (*ottoflowv1alpha1.Workflow, *ottoflowv1alpha1.WorkflowRun) {
+	ns := defaultNamespace
+	wf := &ottoflowv1alpha1.Workflow{
+		ObjectMeta: metav1.ObjectMeta{Name: wfName, Namespace: ns},
+		Spec: ottoflowv1alpha1.WorkflowSpec{
+			Steps: []ottoflowv1alpha1.Step{
+				{
+					Name: "gate",
+					WaitForCallback: &ottoflowv1alpha1.WaitForCallbackStep{
+						Timeout:       "1h",
+						FailurePolicy: failurePolicy,
+					},
+				},
+			},
+		},
+	}
+	wr := &ottoflowv1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{Name: runName, Namespace: ns},
+		Spec:       ottoflowv1alpha1.WorkflowRunSpec{WorkflowRef: ottoflowv1alpha1.WorkflowRef{Name: wfName, Namespace: ns}},
+		Status: ottoflowv1alpha1.WorkflowRunStatus{
+			Phase: ottoflowv1alpha1.WorkflowRunPhaseRunning,
+			PendingCallback: &ottoflowv1alpha1.CallbackState{
+				TokenHash: "irrelevant-for-these-tests",
+				StepName:  "gate",
+				ExpiresAt: time.Now().Add(-1 * time.Hour).Unix(), // already expired
+				CreatedAt: time.Now().Add(-2 * time.Hour).Unix(),
+			},
+		},
+	}
+	return wf, wr
+}
+
+// TestReconcilePendingCallback_TimeoutContinue_RecreatesRunnerJob is the Fix-1 regression test:
+// before this fix, a Continue failurePolicy on timeout cleared PendingCallback and marked the
+// step Skipped without ever recreating the runner Job, so the run went permanently idle. Continue
+// must instead recreate the Job and leave PendingCallback set for the executor's own recovery path.
+func TestReconcilePendingCallback_TimeoutContinue_RecreatesRunnerJob(t *testing.T) {
+	ctx := context.Background()
+	ns := defaultNamespace
+	wf, wr := buildCallbackWorkflowAndRun("wf-timeout-continue", "run-timeout-continue", ottoflowv1alpha1.FailurePolicyContinue)
+	clusterRole := &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "ottoflow-role"}}
+	fakeClient := fake.NewClientBuilder().WithScheme(unitTestScheme).WithStatusSubresource(wr).WithObjects(wf, wr, clusterRole).Build()
+	r := &WorkflowRunReconciler{
+		Client:       fakeClient,
+		Scheme:       unitTestScheme,
+		RunnerConfig: RunnerConfig{RunnerServiceAccount: "controller-manager", RunnerClusterRole: "ottoflow-role"},
+	}
+
+	_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: wr.Name, Namespace: ns}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	updated := &ottoflowv1alpha1.WorkflowRun{}
+	if getErr := fakeClient.Get(ctx, client.ObjectKeyFromObject(wr), updated); getErr != nil {
+		t.Fatal(getErr)
+	}
+	if updated.Status.Phase != ottoflowv1alpha1.WorkflowRunPhaseRunning {
+		t.Errorf("Phase = %v, want Running", updated.Status.Phase)
+	}
+	if updated.Status.PendingCallback == nil {
+		t.Fatal("expected PendingCallback to remain set so the recreated runner's executor applies the Continue recovery path")
+	}
+	if ss, ok := updated.Status.StepStatuses["gate"]; ok {
+		t.Errorf("controller must not mark the gate step itself on Continue; got StepStatuses[gate] = %+v", ss)
+	}
+
+	job := &batchv1.Job{}
+	if getErr := fakeClient.Get(ctx, types.NamespacedName{Name: workflowRunnerJobName(wr.Name), Namespace: ns}, job); getErr != nil {
+		t.Fatalf("expected runner Job to be recreated, got: %v", getErr)
+	}
+}
+
+// TestReconcilePendingCallback_TimeoutContinue_EmitsCallbackTimeoutEvent asserts the CallbackTimeout
+// event still fires on Continue even when there is no old runner Job to react to (e.g. its
+// completion-TTL already garbage collected it) — the event must not depend on the Job-state switch.
+func TestReconcilePendingCallback_TimeoutContinue_EmitsCallbackTimeoutEvent(t *testing.T) {
+	ctx := context.Background()
+	ns := defaultNamespace
+	wf, wr := buildCallbackWorkflowAndRun("wf-timeout-continue-evt", "run-timeout-continue-evt", ottoflowv1alpha1.FailurePolicyContinue)
+	clusterRole := &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "ottoflow-role"}}
+	fakeClient := fake.NewClientBuilder().WithScheme(unitTestScheme).WithStatusSubresource(wr).WithObjects(wf, wr, clusterRole).Build()
+	recorder := events.NewFakeRecorder(10)
+	r := &WorkflowRunReconciler{
+		Client:        fakeClient,
+		Scheme:        unitTestScheme,
+		EventRecorder: recorder,
+		RunnerConfig:  RunnerConfig{RunnerServiceAccount: "controller-manager", RunnerClusterRole: "ottoflow-role"},
+	}
+
+	_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: wr.Name, Namespace: ns}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	select {
+	case evt := <-recorder.Events:
+		if !strings.Contains(evt, "CallbackTimeout") {
+			t.Errorf("event = %q, want CallbackTimeout", evt)
+		}
+	default:
+		t.Error("expected a CallbackTimeout event even when no old runner Job exists to react to")
+	}
+}
+
+// TestReconcilePendingCallback_TimeoutFail_TerminalFailure covers the Fail (default) failurePolicy
+// on timeout: the run must go terminally Failed, PendingCallback must be cleared (so the callback
+// endpoint stops accepting POSTs for a dead run), the gate step must be marked Failed, no runner
+// Job is created, and a CallbackTimeout event is still recorded.
+func TestReconcilePendingCallback_TimeoutFail_TerminalFailure(t *testing.T) {
+	ctx := context.Background()
+	ns := defaultNamespace
+	wf, wr := buildCallbackWorkflowAndRun("wf-timeout-fail", "run-timeout-fail", ottoflowv1alpha1.FailurePolicyFail)
+	fakeClient := fake.NewClientBuilder().WithScheme(unitTestScheme).WithStatusSubresource(wr).WithObjects(wf, wr).Build()
+	recorder := events.NewFakeRecorder(10)
+	r := &WorkflowRunReconciler{Client: fakeClient, Scheme: unitTestScheme, EventRecorder: recorder}
+
+	_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: wr.Name, Namespace: ns}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	updated := &ottoflowv1alpha1.WorkflowRun{}
+	if getErr := fakeClient.Get(ctx, client.ObjectKeyFromObject(wr), updated); getErr != nil {
+		t.Fatal(getErr)
+	}
+	if updated.Status.Phase != ottoflowv1alpha1.WorkflowRunPhaseFailed {
+		t.Errorf("Phase = %v, want Failed", updated.Status.Phase)
+	}
+	if updated.Status.PendingCallback != nil {
+		t.Error("expected PendingCallback to be cleared on terminal failure")
+	}
+	if ss := updated.Status.StepStatuses["gate"]; ss.Phase != ottoflowv1alpha1.StepPhaseFailed {
+		t.Errorf("gate StepStatus.Phase = %v, want Failed", ss.Phase)
+	}
+
+	job := &batchv1.Job{}
+	getErr := fakeClient.Get(ctx, types.NamespacedName{Name: workflowRunnerJobName(wr.Name), Namespace: ns}, job)
+	if !apierrors.IsNotFound(getErr) {
+		t.Errorf("expected no runner Job to be created, Get returned: %v", getErr)
+	}
+
+	select {
+	case evt := <-recorder.Events:
+		if !strings.Contains(evt, "CallbackTimeout") {
+			t.Errorf("event = %q, want CallbackTimeout", evt)
+		}
+	default:
+		t.Error("expected a CallbackTimeout event to be recorded")
+	}
+}
+
+// TestReconcilePendingCallback_FallbackNamespacePolicy_ContinueResumes is the regression test for
+// Fix 1a: the Workflow here only resolves through the ControllerNamespace fallback (workflowRef
+// points at a namespace where it doesn't exist). The old findStepFailurePolicy did its own Get
+// without that fallback, so it could never find the step and always fell back to Fail — wrongly
+// failing a run that should have resumed under its actual Continue policy.
+func TestReconcilePendingCallback_FallbackNamespacePolicy_ContinueResumes(t *testing.T) {
+	ctx := context.Background()
+	wf := &ottoflowv1alpha1.Workflow{
+		ObjectMeta: metav1.ObjectMeta{Name: "cost-analyzer", Namespace: "ottoflow-alt"},
+		Spec: ottoflowv1alpha1.WorkflowSpec{
+			Steps: []ottoflowv1alpha1.Step{
+				{
+					Name: "gate",
+					WaitForCallback: &ottoflowv1alpha1.WaitForCallbackStep{
+						Timeout:       "1h",
+						FailurePolicy: ottoflowv1alpha1.FailurePolicyContinue,
+					},
+				},
+			},
+		},
+	}
+	wr := &ottoflowv1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "run-1", Namespace: "agents"},
+		Spec:       ottoflowv1alpha1.WorkflowRunSpec{WorkflowRef: ottoflowv1alpha1.WorkflowRef{Name: "cost-analyzer", Namespace: "ottoflow"}},
+		Status: ottoflowv1alpha1.WorkflowRunStatus{
+			Phase: ottoflowv1alpha1.WorkflowRunPhaseRunning,
+			PendingCallback: &ottoflowv1alpha1.CallbackState{
+				TokenHash: "irrelevant-for-this-test",
+				StepName:  "gate",
+				ExpiresAt: time.Now().Add(-1 * time.Hour).Unix(),
+				CreatedAt: time.Now().Add(-2 * time.Hour).Unix(),
+			},
+		},
+	}
+	clusterRole := &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "ottoflow-role"}}
+	fakeClient := fake.NewClientBuilder().WithScheme(unitTestScheme).WithStatusSubresource(wr).WithObjects(wf, wr, clusterRole).Build()
+	r := &WorkflowRunReconciler{
+		Client:              fakeClient,
+		Scheme:              unitTestScheme,
+		ControllerNamespace: "ottoflow-alt",
+		RunnerConfig:        RunnerConfig{RunnerServiceAccount: "controller-manager", RunnerClusterRole: "ottoflow-role"},
+	}
+
+	_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "run-1", Namespace: "agents"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	updated := &ottoflowv1alpha1.WorkflowRun{}
+	if getErr := fakeClient.Get(ctx, client.ObjectKeyFromObject(wr), updated); getErr != nil {
+		t.Fatal(getErr)
+	}
+	if updated.Status.Phase == ottoflowv1alpha1.WorkflowRunPhaseFailed {
+		t.Fatal("a Continue policy resolved via the ControllerNamespace fallback must resume the run, not fail it")
+	}
+	if updated.Status.Phase != ottoflowv1alpha1.WorkflowRunPhaseRunning {
+		t.Errorf("Phase = %v, want Running", updated.Status.Phase)
+	}
+	if updated.Status.PendingCallback == nil {
+		t.Error("expected PendingCallback to remain set")
+	}
+}
+
+// TestReconcilePendingCallback_OutputsDelivered_NoOldJob_CreatesRunnerJob is a regression test for
+// the outputs-present branch after extracting resumeRunnerJob: a delivered (non-empty) callback
+// payload must still recreate the runner Job and retain PendingCallback even when there is no old
+// Job object at all (this reconciler is seeing the run for the first time since the callback landed).
+func TestReconcilePendingCallback_OutputsDelivered_NoOldJob_CreatesRunnerJob(t *testing.T) {
+	ctx := context.Background()
+	ns := defaultNamespace
+	wf, wr := buildCallbackWorkflowAndRun("wf-delivered", "run-delivered", ottoflowv1alpha1.FailurePolicyFail)
+	// Not expired, and outputs already delivered: the outputs-present branch must win regardless
+	// of expiry or failurePolicy.
+	wr.Status.PendingCallback.ExpiresAt = time.Now().Add(1 * time.Hour).Unix()
+	wr.Status.PendingCallback.Outputs = apiextensionsv1.JSON{Raw: []byte(`{"approved":true}`)}
+	clusterRole := &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "ottoflow-role"}}
+	fakeClient := fake.NewClientBuilder().WithScheme(unitTestScheme).WithStatusSubresource(wr).WithObjects(wf, wr, clusterRole).Build()
+	r := &WorkflowRunReconciler{
+		Client:       fakeClient,
+		Scheme:       unitTestScheme,
+		RunnerConfig: RunnerConfig{RunnerServiceAccount: "controller-manager", RunnerClusterRole: "ottoflow-role"},
+	}
+
+	_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: wr.Name, Namespace: ns}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	updated := &ottoflowv1alpha1.WorkflowRun{}
+	if getErr := fakeClient.Get(ctx, client.ObjectKeyFromObject(wr), updated); getErr != nil {
+		t.Fatal(getErr)
+	}
+	if updated.Status.Phase != ottoflowv1alpha1.WorkflowRunPhaseRunning {
+		t.Errorf("Phase = %v, want Running", updated.Status.Phase)
+	}
+	if updated.Status.PendingCallback == nil || len(updated.Status.PendingCallback.Outputs.Raw) == 0 {
+		t.Error("expected PendingCallback (with its delivered Outputs) to be retained for the executor")
+	}
+
+	job := &batchv1.Job{}
+	if getErr := fakeClient.Get(ctx, types.NamespacedName{Name: workflowRunnerJobName(wr.Name), Namespace: ns}, job); getErr != nil {
+		t.Fatalf("expected runner Job to be created, got: %v", getErr)
 	}
 }
 

--- a/internal/workflow/controller/controller_unit_test.go
+++ b/internal/workflow/controller/controller_unit_test.go
@@ -982,8 +982,11 @@ func TestWorkflowRunReconciler_Reconcile_WorkflowNotFound_SetsFailed(t *testing.
 	fakeClient := fake.NewClientBuilder().WithScheme(unitTestScheme).WithStatusSubresource(wr).WithObjects(wr).Build()
 	r := &WorkflowRunReconciler{Client: fakeClient, Scheme: unitTestScheme}
 	_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: wr.Name, Namespace: ns}})
-	if err == nil {
-		t.Error("expected error when workflow not found")
+	// A NotFound Workflow reference is a terminal condition, not a transient one: retrying
+	// forever would never make the Workflow appear, so Reconcile marks the run Failed and
+	// returns a nil error so controller-runtime does not keep re-queuing a dead run.
+	if err != nil {
+		t.Errorf("expected no error for a terminal NotFound Workflow reference, got: %v", err)
 	}
 	updated := &ottoflowv1alpha1.WorkflowRun{}
 	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(wr), updated); err != nil {
@@ -991,6 +994,51 @@ func TestWorkflowRunReconciler_Reconcile_WorkflowNotFound_SetsFailed(t *testing.
 	}
 	if updated.Status.Phase != ottoflowv1alpha1.WorkflowRunPhaseFailed {
 		t.Errorf("Phase = %v", updated.Status.Phase)
+	}
+}
+
+// TestWorkflowRunReconciler_Reconcile_WorkflowFetchTransientError_Requeues guards against
+// treating a transient API-server error (not NotFound) the same as an unresolvable Workflow
+// reference. Before this fix, getReferencedWorkflow's caller failed the run unconditionally on
+// any error, so a passing API-server hiccup would permanently kill the WorkflowRun instead of
+// letting controller-runtime retry with backoff.
+func TestWorkflowRunReconciler_Reconcile_WorkflowFetchTransientError_Requeues(t *testing.T) {
+	ctx := context.Background()
+	ns := defaultNamespace
+	wf := &ottoflowv1alpha1.Workflow{
+		ObjectMeta: metav1.ObjectMeta{Name: "wf", Namespace: ns},
+		Spec:       ottoflowv1alpha1.WorkflowSpec{Steps: []ottoflowv1alpha1.Step{{Name: "s1", Expressions: []ottoflowv1alpha1.Expression{{Name: "x", Expression: `"ok"`}}}}},
+	}
+	wr := &ottoflowv1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "run-1", Namespace: ns},
+		Spec:       ottoflowv1alpha1.WorkflowRunSpec{WorkflowRef: ottoflowv1alpha1.WorkflowRef{Name: "wf", Namespace: ns}},
+		Status:     ottoflowv1alpha1.WorkflowRunStatus{Phase: ottoflowv1alpha1.WorkflowRunPhasePending},
+	}
+	baseClient := fake.NewClientBuilder().WithScheme(unitTestScheme).WithStatusSubresource(wr).WithObjects(wf, wr).Build()
+	fakeClient := interceptor.NewClient(baseClient, interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if _, ok := obj.(*ottoflowv1alpha1.Workflow); ok {
+				return apierrors.NewServerTimeout(ottoflowv1alpha1.GroupVersion.WithResource("workflows").GroupResource(), "get", 1)
+			}
+			return c.Get(ctx, key, obj, opts...)
+		},
+	})
+	r := &WorkflowRunReconciler{Client: fakeClient, Scheme: unitTestScheme}
+
+	_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: wr.Name, Namespace: ns}})
+	if err == nil {
+		t.Fatal("expected a non-nil error so controller-runtime requeues with backoff")
+	}
+	if apierrors.IsNotFound(err) {
+		t.Fatalf("expected a transient error, got NotFound: %v", err)
+	}
+
+	updated := &ottoflowv1alpha1.WorkflowRun{}
+	if getErr := fakeClient.Get(ctx, client.ObjectKeyFromObject(wr), updated); getErr != nil {
+		t.Fatal(getErr)
+	}
+	if updated.Status.Phase == ottoflowv1alpha1.WorkflowRunPhaseFailed {
+		t.Errorf("a transient fetch error must not fail the run; Phase = %v", updated.Status.Phase)
 	}
 }
 

--- a/internal/workflow/controller/controller_unit_test.go
+++ b/internal/workflow/controller/controller_unit_test.go
@@ -263,7 +263,18 @@ func TestScheduler_CancelActiveWorkflowRuns(t *testing.T) {
 	wr := &ottoflowv1alpha1.WorkflowRun{
 		ObjectMeta: metav1.ObjectMeta{Name: "run-1", Namespace: ns},
 		Spec:       ottoflowv1alpha1.WorkflowRunSpec{WorkflowRef: ottoflowv1alpha1.WorkflowRef{Name: "wf", Namespace: ns}},
-		Status:     ottoflowv1alpha1.WorkflowRunStatus{Phase: ottoflowv1alpha1.WorkflowRunPhaseRunning},
+		Status: ottoflowv1alpha1.WorkflowRunStatus{
+			Phase: ottoflowv1alpha1.WorkflowRunPhaseRunning,
+			// A live pending callback on the run being replaced: Fix 2b requires the
+			// cancellation path to clear this (via setRunFailed) so a Failed run never keeps
+			// accepting callbacks it can no longer consume.
+			PendingCallback: &ottoflowv1alpha1.CallbackState{
+				TokenHash: "irrelevant-for-this-test",
+				StepName:  "gate",
+				ExpiresAt: time.Now().Add(1 * time.Hour).Unix(),
+				CreatedAt: time.Now().Unix(),
+			},
+		},
 	}
 	wr.Labels = map[string]string{"ottoflow.nirmata.io/workflow": "wf", "ottoflow.nirmata.io/trigger": "cron"}
 	fakeClient := fake.NewClientBuilder().WithScheme(unitTestScheme).WithStatusSubresource(wr).WithObjects(wf, wr).Build()
@@ -280,6 +291,9 @@ func TestScheduler_CancelActiveWorkflowRuns(t *testing.T) {
 	}
 	if updated.Status.Message == "" || !strings.Contains(updated.Status.Message, "Replaced") {
 		t.Errorf("Message %q should contain Replaced", updated.Status.Message)
+	}
+	if updated.Status.PendingCallback != nil {
+		t.Errorf("PendingCallback = %+v, want nil after cancellation", updated.Status.PendingCallback)
 	}
 }
 

--- a/internal/workflow/controller/controller_unit_test.go
+++ b/internal/workflow/controller/controller_unit_test.go
@@ -2107,6 +2107,49 @@ func TestGetReferencedWorkflow_PrimaryLookupSucceeds(t *testing.T) {
 	}
 }
 
+// TestWorkflowRunReconciler_Reconcile_FallbackWorkflowFetchTransientError_Requeues is the
+// regression test for Fix 3 (issue #33): the primary Workflow lookup is a genuine NotFound, and
+// the ControllerNamespace fallback lookup fails with a transient (non-NotFound) API error. Before
+// the fix, getReferencedWorkflow discarded the fallback error and always returned the wrapped
+// primary NotFound, so the caller's apierrors.IsNotFound check terminally failed the run instead
+// of requeuing on what was really just a passing API-server hiccup on the fallback Get.
+func TestWorkflowRunReconciler_Reconcile_FallbackWorkflowFetchTransientError_Requeues(t *testing.T) {
+	ctx := context.Background()
+	wr := &ottoflowv1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "run-1", Namespace: "agents"},
+		Spec:       ottoflowv1alpha1.WorkflowRunSpec{WorkflowRef: ottoflowv1alpha1.WorkflowRef{Name: "cost-analyzer", Namespace: "ottoflow"}},
+		Status:     ottoflowv1alpha1.WorkflowRunStatus{Phase: ottoflowv1alpha1.WorkflowRunPhasePending},
+	}
+	// No Workflow exists anywhere: the primary Get (namespace "ottoflow") is a real NotFound.
+	baseClient := fake.NewClientBuilder().WithScheme(unitTestScheme).WithStatusSubresource(wr).WithObjects(wr).Build()
+	fakeClient := interceptor.NewClient(baseClient, interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if _, ok := obj.(*ottoflowv1alpha1.Workflow); ok && key.Namespace == "ottoflow-alt" {
+				// The fallback Get (in ControllerNamespace) hits a transient API-server error.
+				return apierrors.NewServerTimeout(ottoflowv1alpha1.GroupVersion.WithResource("workflows").GroupResource(), "get", 1)
+			}
+			return c.Get(ctx, key, obj, opts...)
+		},
+	})
+	r := &WorkflowRunReconciler{Client: fakeClient, Scheme: unitTestScheme, ControllerNamespace: "ottoflow-alt"}
+
+	_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: wr.Name, Namespace: "agents"}})
+	if err == nil {
+		t.Fatal("expected a non-nil error so controller-runtime requeues with backoff")
+	}
+	if apierrors.IsNotFound(err) {
+		t.Fatalf("expected a transient error, got NotFound: %v", err)
+	}
+
+	updated := &ottoflowv1alpha1.WorkflowRun{}
+	if getErr := fakeClient.Get(ctx, client.ObjectKeyFromObject(wr), updated); getErr != nil {
+		t.Fatal(getErr)
+	}
+	if updated.Status.Phase == ottoflowv1alpha1.WorkflowRunPhaseFailed {
+		t.Errorf("a transient fallback fetch error must not fail the run; Phase = %v", updated.Status.Phase)
+	}
+}
+
 // --- reconcilePendingCallback (waitForCallback timeout / resume) tests ---
 
 // buildCallbackWorkflowAndRun builds a minimal Workflow with a single waitForCallback step named
@@ -2366,6 +2409,60 @@ func TestReconcilePendingCallback_OutputsDelivered_NoOldJob_CreatesRunnerJob(t *
 	job := &batchv1.Job{}
 	if getErr := fakeClient.Get(ctx, types.NamespacedName{Name: workflowRunnerJobName(wr.Name), Namespace: ns}, job); getErr != nil {
 		t.Fatalf("expected runner Job to be created, got: %v", getErr)
+	}
+}
+
+// TestReconcilePendingCallback_ActiveResumeJobFailedNoCondition_StaysMonitoring is the regression
+// test for Fix 1: a recreated resume Job with backoffLimit>0 can report Status.Failed>0 for an
+// in-flight pod retry well before Kubernetes sets the terminal JobFailed *condition*. Before the
+// fix, resumeRunnerJob's active-Job branch returned proceed=true unconditionally, so the caller
+// fell through to the normal Job-creation block's crude `job.Status.Failed>0` check, which
+// terminally failed the run (or restarted it) on what was actually just a transient pod failure —
+// defeating the JobFailed-condition gate in resumeRunnerJob's own JobFailed case. The fix keeps
+// monitoring inside the pending-callback path instead of falling through.
+func TestReconcilePendingCallback_ActiveResumeJobFailedNoCondition_StaysMonitoring(t *testing.T) {
+	ctx := context.Background()
+	ns := defaultNamespace
+	wf, wr := buildCallbackWorkflowAndRun("wf-active-resume", "run-active-resume", ottoflowv1alpha1.FailurePolicyFail)
+	// Not expired, and outputs already delivered: the outputs-present branch routes straight into
+	// resumeRunnerJob regardless of expiry or failurePolicy.
+	wr.Status.PendingCallback.ExpiresAt = time.Now().Add(1 * time.Hour).Unix()
+	wr.Status.PendingCallback.Outputs = apiextensionsv1.JSON{Raw: []byte(`{"approved":true}`)}
+
+	// The recreated resume Job already exists, is active, and has one failed pod (an in-flight
+	// backoffLimit>0 retry) but NO JobFailed condition yet.
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: workflowRunnerJobName(wr.Name), Namespace: ns},
+		Spec:       batchv1.JobSpec{BackoffLimit: ptr.To(int32(3))},
+		Status:     batchv1.JobStatus{Active: 1, Failed: 1},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(unitTestScheme).WithStatusSubresource(wr).WithObjects(wf, wr, job).Build()
+	r := &WorkflowRunReconciler{Client: fakeClient, Scheme: unitTestScheme}
+
+	result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: wr.Name, Namespace: ns}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.RequeueAfter != 2*time.Second {
+		t.Errorf("RequeueAfter = %v, want 2s", result.RequeueAfter)
+	}
+
+	updatedJob := &batchv1.Job{}
+	if getErr := fakeClient.Get(ctx, client.ObjectKeyFromObject(job), updatedJob); getErr != nil {
+		t.Fatalf("expected resume Job to still exist (not deleted), got: %v", getErr)
+	}
+
+	updated := &ottoflowv1alpha1.WorkflowRun{}
+	if getErr := fakeClient.Get(ctx, client.ObjectKeyFromObject(wr), updated); getErr != nil {
+		t.Fatal(getErr)
+	}
+	if updated.Status.Phase != ottoflowv1alpha1.WorkflowRunPhaseRunning {
+		t.Errorf("Phase = %v, want Running", updated.Status.Phase)
+	}
+	if updated.Status.PendingCallback == nil {
+		t.Error("expected PendingCallback to be retained while monitoring the active resume Job")
 	}
 }
 

--- a/internal/workflow/controller/scheduler.go
+++ b/internal/workflow/controller/scheduler.go
@@ -235,8 +235,7 @@ func (s *Scheduler) cancelActiveWorkflowRuns(ctx context.Context, workflow *otto
 		wr := &list.Items[i]
 		if wr.Status.Phase == ottoflowv1alpha1.WorkflowRunPhasePending ||
 			wr.Status.Phase == ottoflowv1alpha1.WorkflowRunPhaseRunning {
-			wr.Status.Phase = ottoflowv1alpha1.WorkflowRunPhaseFailed
-			wr.Status.Message = "Replaced by newer cron trigger execution"
+			setRunFailed(wr, "Replaced by newer cron trigger execution")
 			if err := s.client.Status().Update(ctx, wr); err != nil {
 				return fmt.Errorf("failed to cancel WorkflowRun %s: %w", wr.Name, err)
 			}

--- a/internal/workflow/controller/workflowrun_controller.go
+++ b/internal/workflow/controller/workflowrun_controller.go
@@ -153,11 +153,15 @@ func (r *WorkflowRunReconciler) reconcileJobExecution(ctx context.Context, req c
 
 	workflow, workflowNamespace, err := r.getReferencedWorkflow(ctx, workflowRun)
 	if err != nil {
-		logger.Error(err, "failed to get Workflow", logging.KeyWorkflowRun, req.Name, logging.KeyNamespace, req.Namespace)
-		setRunFailed(workflowRun, err.Error())
-		if err := r.Status().Update(ctx, workflowRun); err != nil {
-			return ctrl.Result{}, err
+		if apierrors.IsNotFound(err) {
+			logger.Error(err, "referenced Workflow not found; failing run", logging.KeyWorkflowRun, req.Name, logging.KeyNamespace, req.Namespace)
+			setRunFailed(workflowRun, err.Error())
+			if err := r.Status().Update(ctx, workflowRun); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{}, nil
 		}
+		logger.Error(err, "failed to resolve referenced Workflow; requeuing", logging.KeyWorkflowRun, req.Name, logging.KeyNamespace, req.Namespace)
 		return ctrl.Result{}, err
 	}
 	// workflow is used below for checkpointing config and run policy
@@ -340,7 +344,7 @@ func (r *WorkflowRunReconciler) getReferencedWorkflow(ctx context.Context, workf
 		}
 	}
 
-	return nil, "", fmt.Errorf("failed to get Workflow %s: %v", workflowKey, err)
+	return nil, "", fmt.Errorf("failed to get Workflow %s: %w", workflowKey, err)
 }
 
 func workflowRunnerJobName(runName string) string {

--- a/internal/workflow/controller/workflowrun_controller.go
+++ b/internal/workflow/controller/workflowrun_controller.go
@@ -1305,25 +1305,24 @@ func (r *WorkflowRunReconciler) reconcilePendingCallback(ctx context.Context, re
 	if now.Unix() > cb.ExpiresAt {
 		failurePolicy := findStepFailurePolicy(workflow, cb.StepName)
 
+		// The event fires unconditionally regardless of failurePolicy; only the log level and
+		// the resulting action differ below.
+		if r.EventRecorder != nil {
+			r.EventRecorder.Eventf(workflowRun, nil, corev1.EventTypeWarning, "CallbackTimeout",
+				"CallbackTimeout", "Callback timeout for step %q", cb.StepName)
+		}
+
 		if failurePolicy == ottoflowv1alpha1.FailurePolicyContinue {
 			// Do NOT clear PendingCallback and do NOT mark the step here: leaving PendingCallback
 			// set is required so resumeRunnerJob recreates the runner Job, whose executor applies
 			// the Continue recovery path on resume (empty outputs → step Succeeded → downstream
 			// steps run). Clearing it here would mean the recreated runner never re-arms.
 			logger.V(1).Info("waitForCallback: token expired, applying Continue; resuming run", "step", cb.StepName)
-			if r.EventRecorder != nil {
-				r.EventRecorder.Eventf(workflowRun, nil, corev1.EventTypeWarning, "CallbackTimeout",
-					"CallbackTimeout", "Callback timeout for step %q", cb.StepName)
-			}
 			return r.resumeRunnerJob(ctx, req, workflow, workflowRun)
 		}
 
 		logger.Info("waitForCallback: token expired, applying failurePolicy Fail",
 			logging.KeyWorkflowRun, req.Name, "step", cb.StepName)
-		if r.EventRecorder != nil {
-			r.EventRecorder.Eventf(workflowRun, nil, corev1.EventTypeWarning, "CallbackTimeout",
-				"CallbackTimeout", "Callback timeout for step %q", cb.StepName)
-		}
 
 		if workflowRun.Status.StepStatuses == nil {
 			workflowRun.Status.StepStatuses = make(map[string]ottoflowv1alpha1.StepStatus)

--- a/internal/workflow/controller/workflowrun_controller.go
+++ b/internal/workflow/controller/workflowrun_controller.go
@@ -341,6 +341,10 @@ func (r *WorkflowRunReconciler) getReferencedWorkflow(ctx context.Context, workf
 			klog.Warningf("Workflow %s not found; falling back to controller namespace %q. The upstream caller should set workflowRef.namespace=%q to make this lookup explicit.",
 				workflowKey, r.ControllerNamespace, r.ControllerNamespace)
 			return fallback, r.ControllerNamespace, nil
+		} else if !apierrors.IsNotFound(fbErr) {
+			// Transient fallback error (e.g. API server timeout): the caller must requeue, not
+			// terminally fail the run on what would otherwise be treated as a NotFound.
+			return nil, "", fmt.Errorf("failed to get Workflow %s in controller namespace %q: %w", fallbackKey, r.ControllerNamespace, fbErr)
 		}
 	}
 
@@ -1363,14 +1367,14 @@ func (r *WorkflowRunReconciler) resumeRunnerJob(ctx context.Context, req ctrl.Re
 		stepName = cb.StepName
 	}
 
-	ensureRunning := func() (ctrl.Result, bool, error) {
+	ensureRunning := func() error {
 		if workflowRun.Status.Phase != ottoflowv1alpha1.WorkflowRunPhaseRunning {
 			workflowRun.Status.Phase = ottoflowv1alpha1.WorkflowRunPhaseRunning
 			if uErr := r.Status().Update(ctx, workflowRun); uErr != nil {
-				return ctrl.Result{}, false, uErr
+				return uErr
 			}
 		}
-		return ctrl.Result{}, true, nil
+		return nil
 	}
 
 	jobName := workflowRunnerJobName(workflowRun.Name)
@@ -1380,7 +1384,10 @@ func (r *WorkflowRunReconciler) resumeRunnerJob(ctx context.Context, req ctrl.Re
 	switch {
 	case apierrors.IsNotFound(err):
 		// Old paused Job gone (or none) — ready to resume.
-		return ensureRunning() // proceed → fall through to the creation block
+		if err := ensureRunning(); err != nil {
+			return ctrl.Result{}, false, err
+		}
+		return ctrl.Result{}, true, nil // proceed → fall through to the creation block
 	case err != nil:
 		return ctrl.Result{}, false, err
 	case jobConditionTrue(job, batchv1.JobComplete) || job.Status.Succeeded > 0:
@@ -1404,8 +1411,15 @@ func (r *WorkflowRunReconciler) resumeRunnerJob(ctx context.Context, req ctrl.Re
 		res, _, hfErr := r.handleFailedJob(ctx, workflowRun, workflow, job, jobName)
 		return res, false, hfErr
 	default:
-		// Job exists and is still active ⇒ resume already in progress. Monitor.
-		return ensureRunning()
+		// Job exists and is still active ⇒ resume already in progress. Do NOT proceed: falling
+		// through to the normal Job-creation block would hit its crude job.Status.Failed>0 check
+		// instead of the JobFailed-*condition* gate above, so monitoring stays here where that
+		// gate is authoritative for backoffLimit>0 (a transient first-pod failure sets Failed>0
+		// with no JobFailed condition yet).
+		if err := ensureRunning(); err != nil {
+			return ctrl.Result{}, false, err
+		}
+		return ctrl.Result{RequeueAfter: 2 * time.Second}, false, nil
 	}
 }
 

--- a/internal/workflow/controller/workflowrun_controller.go
+++ b/internal/workflow/controller/workflowrun_controller.go
@@ -154,8 +154,7 @@ func (r *WorkflowRunReconciler) reconcileJobExecution(ctx context.Context, req c
 	workflow, workflowNamespace, err := r.getReferencedWorkflow(ctx, workflowRun)
 	if err != nil {
 		logger.Error(err, "failed to get Workflow", logging.KeyWorkflowRun, req.Name, logging.KeyNamespace, req.Namespace)
-		workflowRun.Status.Phase = ottoflowv1alpha1.WorkflowRunPhaseFailed
-		workflowRun.Status.Message = err.Error()
+		setRunFailed(workflowRun, err.Error())
 		if err := r.Status().Update(ctx, workflowRun); err != nil {
 			return ctrl.Result{}, err
 		}
@@ -166,7 +165,12 @@ func (r *WorkflowRunReconciler) reconcileJobExecution(ctx context.Context, req c
 	// --- waitForCallback handling ---
 	// If a callback is pending, handle timeout or wait for callback/timeout.
 	if workflowRun.Status.PendingCallback != nil {
-		return r.reconcilePendingCallback(ctx, req, workflowRun)
+		res, proceed, err := r.reconcilePendingCallback(ctx, req, workflow, workflowRun)
+		if err != nil || !proceed {
+			return res, err
+		}
+		// proceed == true: resume — fall through to the normal Job-creation block below,
+		// with PendingCallback still set so the executor consumes the outputs.
 	}
 
 	jobName := workflowRunnerJobName(workflowRun.Name)
@@ -193,8 +197,7 @@ func (r *WorkflowRunReconciler) reconcileJobExecution(ctx context.Context, req c
 				return ctrl.Result{}, te.err
 			}
 			logger.Error(err, "failed to build runner Job", logging.KeyWorkflow, workflowRun.Spec.WorkflowRef.Name, logging.KeyWorkflowRun, req.Name, logging.KeyNamespace, req.Namespace)
-			workflowRun.Status.Phase = ottoflowv1alpha1.WorkflowRunPhaseFailed
-			workflowRun.Status.Message = fmt.Sprintf("Failed to build runner Job: %v", err)
+			setRunFailed(workflowRun, fmt.Sprintf("Failed to build runner Job: %v", err))
 			if err := r.Status().Update(ctx, workflowRun); err != nil {
 				return ctrl.Result{}, err
 			}
@@ -206,8 +209,7 @@ func (r *WorkflowRunReconciler) reconcileJobExecution(ctx context.Context, req c
 				return ctrl.Result{RequeueAfter: time.Second}, nil
 			}
 			logger.Error(err, "failed to ensure runner service account access", logging.KeyWorkflow, workflowRun.Spec.WorkflowRef.Name, logging.KeyWorkflowRun, req.Name, logging.KeyNamespace, req.Namespace)
-			workflowRun.Status.Phase = ottoflowv1alpha1.WorkflowRunPhaseFailed
-			workflowRun.Status.Message = fmt.Sprintf("Failed to prepare runner access: %v", err)
+			setRunFailed(workflowRun, fmt.Sprintf("Failed to prepare runner access: %v", err))
 			if err := r.Status().Update(ctx, workflowRun); err != nil {
 				return ctrl.Result{}, err
 			}
@@ -216,8 +218,7 @@ func (r *WorkflowRunReconciler) reconcileJobExecution(ctx context.Context, req c
 		sourceNamespace := runnerSecretSourceNamespace(r.RunnerConfig, workflowNamespace)
 		if err := r.ensureRunnerSecrets(ctx, workflowRun, createdJob, sourceNamespace); err != nil {
 			logger.Error(err, "failed to ensure runner secrets", logging.KeyWorkflow, workflowRun.Spec.WorkflowRef.Name, logging.KeyWorkflowRun, req.Name, logging.KeyNamespace, req.Namespace)
-			workflowRun.Status.Phase = ottoflowv1alpha1.WorkflowRunPhaseFailed
-			workflowRun.Status.Message = fmt.Sprintf("Failed to prepare runner secrets: %v", err)
+			setRunFailed(workflowRun, fmt.Sprintf("Failed to prepare runner secrets: %v", err))
 			if err := r.Status().Update(ctx, workflowRun); err != nil {
 				return ctrl.Result{}, err
 			}
@@ -232,8 +233,7 @@ func (r *WorkflowRunReconciler) reconcileJobExecution(ctx context.Context, req c
 				}
 			} else {
 				logger.Error(err, "failed to create runner Job", logging.KeyWorkflow, workflowRun.Spec.WorkflowRef.Name, logging.KeyWorkflowRun, req.Name, logging.KeyNamespace, req.Namespace, "job", jobKey)
-				workflowRun.Status.Phase = ottoflowv1alpha1.WorkflowRunPhaseFailed
-				workflowRun.Status.Message = fmt.Sprintf("Failed to create runner Job %s: %v", jobName, err)
+				setRunFailed(workflowRun, fmt.Sprintf("Failed to create runner Job %s: %v", jobName, err))
 				if err := r.Status().Update(ctx, workflowRun); err != nil {
 					return ctrl.Result{}, err
 				}
@@ -356,6 +356,16 @@ func workflowRunnerJobName(runName string) string {
 	suffix := fmt.Sprintf("%08x", h.Sum64())
 	prefix := strings.TrimSuffix(base[:63-len(suffix)-1], "-") // reserve "-" + suffix
 	return prefix + "-" + suffix
+}
+
+// jobConditionTrue reports whether the Job has a condition of the given type set to True.
+func jobConditionTrue(job *batchv1.Job, t batchv1.JobConditionType) bool {
+	for _, c := range job.Status.Conditions {
+		if c.Type == t && c.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
 }
 
 // RunnerClusterRole is required and validated non-empty at startup (cmd/controller/main.go); no safe default.
@@ -1174,6 +1184,21 @@ func (r *WorkflowRunReconciler) handleFailedJob(ctx context.Context, workflowRun
 	return r.markRunTerminallyFailed(ctx, workflowRun, jobName, terminationReason, attempts)
 }
 
+// setRunFailed transitions a WorkflowRun to the terminal Failed phase with the given message and
+// always clears any pending callback. This enforces the invariant that a run in phase Failed never
+// keeps a live callback endpoint: the HTTP callback server admits a POST based only on
+// Status.PendingCallback (token + expiry) and never checks Status.Phase, so a Failed run that still
+// carried a PendingCallback would keep accepting callbacks that can never be consumed (a dead run
+// whose endpoint still returns 200). Every terminal Failed transition must go through this helper.
+// It deliberately does NOT touch Execution, CompletionTime, or step statuses — call sites set those
+// as needed. It must NOT be used on the transient-retry path (retryTransientFailure), which keeps
+// PendingCallback so the recreated runner can consume the delivered callback outputs.
+func setRunFailed(workflowRun *ottoflowv1alpha1.WorkflowRun, message string) {
+	workflowRun.Status.Phase = ottoflowv1alpha1.WorkflowRunPhaseFailed
+	workflowRun.Status.Message = message
+	workflowRun.Status.PendingCallback = nil
+}
+
 // markRunTerminallyFailed marks a WorkflowRun as Failed and cleans up the checkpoint ConfigMap.
 func (r *WorkflowRunReconciler) markRunTerminallyFailed(ctx context.Context, workflowRun *ottoflowv1alpha1.WorkflowRun, jobName, terminationReason string, attempts int32) (ctrl.Result, bool, error) {
 	now := metav1.Now()
@@ -1186,9 +1211,8 @@ func (r *WorkflowRunReconciler) markRunTerminallyFailed(ctx context.Context, wor
 	default:
 		msg = fmt.Sprintf("Runner Job %s failed", jobName)
 	}
-	workflowRun.Status.Phase = ottoflowv1alpha1.WorkflowRunPhaseFailed
+	setRunFailed(workflowRun, msg)
 	workflowRun.Status.CompletionTime = &now
-	workflowRun.Status.Message = msg
 	if workflowRun.Status.Execution == nil {
 		workflowRun.Status.Execution = &ottoflowv1alpha1.WorkflowRunExecutionStatus{}
 	}
@@ -1255,35 +1279,67 @@ func warnCheckpointForEach(ctx context.Context, workflow *ottoflowv1alpha1.Workf
 //   - If the token has expired, apply failurePolicy (mark step Failed/Skipped, fail/continue workflow).
 //   - If outputs have been set by the callback handler, recreate the runner Job so it can resume.
 //   - Otherwise requeue to re-check at expiry time.
-func (r *WorkflowRunReconciler) reconcilePendingCallback(ctx context.Context, req ctrl.Request, workflowRun *ottoflowv1alpha1.WorkflowRun) (ctrl.Result, error) {
+//
+// Returns (result, proceed, err): when proceed is true, the caller falls through to the normal
+// Job-creation block instead of returning immediately. This is what lets a resumed run's runner
+// Job actually get (re)created — previously this function never fell through, so once
+// PendingCallback was set, every reconcile was permanently routed here and no Job was ever
+// created after the old one was deleted (nirmata/ottoflow#18).
+func (r *WorkflowRunReconciler) reconcilePendingCallback(ctx context.Context, req ctrl.Request, workflow *ottoflowv1alpha1.Workflow, workflowRun *ottoflowv1alpha1.WorkflowRun) (ctrl.Result, bool, error) {
 	logger := log.FromContext(ctx)
 	cb := workflowRun.Status.PendingCallback
 	now := time.Now()
 
 	// Check outputs FIRST: a callback arriving just before expiry must not be lost by a racing timeout check.
 	if len(cb.Outputs.Raw) > 0 {
-		logger.Info("waitForCallback: callback received, recreating runner Job to resume",
-			logging.KeyWorkflowRun, req.Name, "step", cb.StepName)
-		// Fall through to normal job creation by clearing PendingCallback from in-memory view
-		// (the executor will read it from the real status and pick up outputs)
-		// We need to delete the old completed job first if it exists
-		jobName := workflowRunnerJobName(workflowRun.Name)
-		job := &batchv1.Job{}
-		jobKey := types.NamespacedName{Name: jobName, Namespace: workflowRun.Namespace}
-		if err := r.Get(ctx, jobKey, job); err == nil {
-			// Delete old completed job (foreground: blocks until pods are gone, preventing AlreadyExists on recreate)
-			if err := r.Delete(ctx, job, client.PropagationPolicy(metav1.DeletePropagationForeground)); err != nil && !apierrors.IsNotFound(err) {
-				logger.Error(err, "failed to delete old runner Job for callback resume")
-				return ctrl.Result{}, err
+		// Both the "old Job gone" and "resume already active" outcomes converge on the same
+		// action: mark the run Running (so the recreated runner restores from checkpoint via
+		// loadCheckpointIfNeeded instead of re-running completed steps) and proceed to Job
+		// creation. PendingCallback is intentionally left set for the executor to consume.
+		ensureRunning := func() (ctrl.Result, bool, error) {
+			if workflowRun.Status.Phase != ottoflowv1alpha1.WorkflowRunPhaseRunning {
+				workflowRun.Status.Phase = ottoflowv1alpha1.WorkflowRunPhaseRunning
+				if uErr := r.Status().Update(ctx, workflowRun); uErr != nil {
+					return ctrl.Result{}, false, uErr
+				}
 			}
-			// Foreground deletion is not instantaneous — re-check before proceeding
-			existing := &batchv1.Job{}
-			if err := r.Get(ctx, jobKey, existing); err == nil {
-				return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
-			}
+			return ctrl.Result{}, true, nil
 		}
-		// Job is gone — next reconcile (PendingCallback still has outputs) will create a fresh Job
-		return ctrl.Result{Requeue: true}, nil
+
+		jobName := workflowRunnerJobName(workflowRun.Name)
+		jobKey := types.NamespacedName{Name: jobName, Namespace: workflowRun.Namespace}
+		job := &batchv1.Job{}
+		err := r.Get(ctx, jobKey, job)
+		switch {
+		case apierrors.IsNotFound(err):
+			// Old paused Job gone (or none) — ready to resume.
+			return ensureRunning() // proceed → fall through to the creation block
+		case err != nil:
+			return ctrl.Result{}, false, err
+		case jobConditionTrue(job, batchv1.JobComplete) || job.Status.Succeeded > 0:
+			// Old paused runner Job exited 0 (Complete). Delete so we can recreate the same name.
+			// Checked before the failure case: a Job that succeeded after an earlier pod retry
+			// (backoffLimit>0) reports both Complete and Failed>0, and "completed" must win.
+			logger.Info("waitForCallback: callback received, recreating runner Job to resume",
+				logging.KeyWorkflowRun, req.Name, "step", cb.StepName)
+			if job.DeletionTimestamp == nil {
+				if dErr := r.Delete(ctx, job, client.PropagationPolicy(metav1.DeletePropagationForeground)); dErr != nil && !apierrors.IsNotFound(dErr) {
+					logger.Error(dErr, "failed to delete old runner Job for callback resume")
+					return ctrl.Result{}, false, dErr
+				}
+			}
+			return ctrl.Result{RequeueAfter: 2 * time.Second}, false, nil
+		case jobConditionTrue(job, batchv1.JobFailed):
+			// A recreated resume Job terminally failed (backoffLimit exhausted). Gated on the
+			// JobFailed *condition*, not job.Status.Failed>0, so an in-flight retry is not misread
+			// as terminal failure. Route through the standard failure path (attempt cap + terminal
+			// fail) to avoid a hot delete/recreate loop.
+			res, _, hfErr := r.handleFailedJob(ctx, workflowRun, workflow, job, jobName)
+			return res, false, hfErr
+		default:
+			// Job exists and is still active ⇒ resume already in progress. Monitor.
+			return ensureRunning()
+		}
 	}
 
 	// Emit CallbackTimeout event and apply failurePolicy
@@ -1309,21 +1365,20 @@ func (r *WorkflowRunReconciler) reconcilePendingCallback(ctx context.Context, re
 			ss.Message = "Callback timed out; step skipped (failurePolicy: Continue)"
 			workflowRun.Status.StepStatuses[cb.StepName] = ss
 			if err := r.Status().Update(ctx, workflowRun); err != nil {
-				return ctrl.Result{}, err
+				return ctrl.Result{}, false, err
 			}
-			return ctrl.Result{Requeue: true}, nil
+			return ctrl.Result{Requeue: true}, false, nil
 		}
 
 		ss.Phase = ottoflowv1alpha1.StepPhaseFailed
 		ss.Error = "callback timeout: no callback received within the configured timeout"
 		ss.Message = ss.Error
 		workflowRun.Status.StepStatuses[cb.StepName] = ss
-		workflowRun.Status.Phase = ottoflowv1alpha1.WorkflowRunPhaseFailed
-		workflowRun.Status.Message = fmt.Sprintf("Step %q timed out waiting for callback", cb.StepName)
+		setRunFailed(workflowRun, fmt.Sprintf("Step %q timed out waiting for callback", cb.StepName))
 		if err := r.Status().Update(ctx, workflowRun); err != nil {
-			return ctrl.Result{}, err
+			return ctrl.Result{}, false, err
 		}
-		return ctrl.Result{}, nil
+		return ctrl.Result{}, false, nil
 	}
 
 	// Still waiting: requeue at expiry time
@@ -1334,7 +1389,7 @@ func (r *WorkflowRunReconciler) reconcilePendingCallback(ctx context.Context, re
 	logger.V(1).Info("waitForCallback: still waiting for callback",
 		logging.KeyWorkflowRun, req.Name, "step", cb.StepName,
 		"requeueIn", requeueIn)
-	return ctrl.Result{RequeueAfter: requeueIn + time.Second}, nil
+	return ctrl.Result{RequeueAfter: requeueIn + time.Second}, false, nil
 }
 
 // findStepFailurePolicy looks up the failurePolicy for a step by name in the referenced Workflow.

--- a/internal/workflow/controller/workflowrun_controller.go
+++ b/internal/workflow/controller/workflowrun_controller.go
@@ -1280,7 +1280,9 @@ func warnCheckpointForEach(ctx context.Context, workflow *ottoflowv1alpha1.Workf
 }
 
 // reconcilePendingCallback handles the WaitForCallback case:
-//   - If the token has expired, apply failurePolicy (mark step Failed/Skipped, fail/continue workflow).
+//   - If the token has expired, apply failurePolicy: Fail marks the step Failed and fails the
+//     run; Continue leaves the step's callback armed and recreates the runner Job so the executor
+//     resumes it with empty outputs.
 //   - If outputs have been set by the callback handler, recreate the runner Job so it can resume.
 //   - Otherwise requeue to re-check at expiry time.
 //
@@ -1296,63 +1298,28 @@ func (r *WorkflowRunReconciler) reconcilePendingCallback(ctx context.Context, re
 
 	// Check outputs FIRST: a callback arriving just before expiry must not be lost by a racing timeout check.
 	if len(cb.Outputs.Raw) > 0 {
-		// Both the "old Job gone" and "resume already active" outcomes converge on the same
-		// action: mark the run Running (so the recreated runner restores from checkpoint via
-		// loadCheckpointIfNeeded instead of re-running completed steps) and proceed to Job
-		// creation. PendingCallback is intentionally left set for the executor to consume.
-		ensureRunning := func() (ctrl.Result, bool, error) {
-			if workflowRun.Status.Phase != ottoflowv1alpha1.WorkflowRunPhaseRunning {
-				workflowRun.Status.Phase = ottoflowv1alpha1.WorkflowRunPhaseRunning
-				if uErr := r.Status().Update(ctx, workflowRun); uErr != nil {
-					return ctrl.Result{}, false, uErr
-				}
-			}
-			return ctrl.Result{}, true, nil
-		}
-
-		jobName := workflowRunnerJobName(workflowRun.Name)
-		jobKey := types.NamespacedName{Name: jobName, Namespace: workflowRun.Namespace}
-		job := &batchv1.Job{}
-		err := r.Get(ctx, jobKey, job)
-		switch {
-		case apierrors.IsNotFound(err):
-			// Old paused Job gone (or none) — ready to resume.
-			return ensureRunning() // proceed → fall through to the creation block
-		case err != nil:
-			return ctrl.Result{}, false, err
-		case jobConditionTrue(job, batchv1.JobComplete) || job.Status.Succeeded > 0:
-			// Old paused runner Job exited 0 (Complete). Delete so we can recreate the same name.
-			// Checked before the failure case: a Job that succeeded after an earlier pod retry
-			// (backoffLimit>0) reports both Complete and Failed>0, and "completed" must win.
-			logger.Info("waitForCallback: callback received, recreating runner Job to resume",
-				logging.KeyWorkflowRun, req.Name, "step", cb.StepName)
-			if job.DeletionTimestamp == nil {
-				if dErr := r.Delete(ctx, job, client.PropagationPolicy(metav1.DeletePropagationForeground)); dErr != nil && !apierrors.IsNotFound(dErr) {
-					logger.Error(dErr, "failed to delete old runner Job for callback resume")
-					return ctrl.Result{}, false, dErr
-				}
-			}
-			return ctrl.Result{RequeueAfter: 2 * time.Second}, false, nil
-		case jobConditionTrue(job, batchv1.JobFailed):
-			// A recreated resume Job terminally failed (backoffLimit exhausted). Gated on the
-			// JobFailed *condition*, not job.Status.Failed>0, so an in-flight retry is not misread
-			// as terminal failure. Route through the standard failure path (attempt cap + terminal
-			// fail) to avoid a hot delete/recreate loop.
-			res, _, hfErr := r.handleFailedJob(ctx, workflowRun, workflow, job, jobName)
-			return res, false, hfErr
-		default:
-			// Job exists and is still active ⇒ resume already in progress. Monitor.
-			return ensureRunning()
-		}
+		return r.resumeRunnerJob(ctx, req, workflow, workflowRun)
 	}
 
 	// Emit CallbackTimeout event and apply failurePolicy
 	if now.Unix() > cb.ExpiresAt {
-		logger.Info("waitForCallback: token expired, applying failurePolicy",
+		failurePolicy := findStepFailurePolicy(workflow, cb.StepName)
+
+		if failurePolicy == ottoflowv1alpha1.FailurePolicyContinue {
+			// Do NOT clear PendingCallback and do NOT mark the step here: leaving PendingCallback
+			// set is required so resumeRunnerJob recreates the runner Job, whose executor applies
+			// the Continue recovery path on resume (empty outputs → step Succeeded → downstream
+			// steps run). Clearing it here would mean the recreated runner never re-arms.
+			logger.V(1).Info("waitForCallback: token expired, applying Continue; resuming run", "step", cb.StepName)
+			if r.EventRecorder != nil {
+				r.EventRecorder.Eventf(workflowRun, nil, corev1.EventTypeWarning, "CallbackTimeout",
+					"CallbackTimeout", "Callback timeout for step %q", cb.StepName)
+			}
+			return r.resumeRunnerJob(ctx, req, workflow, workflowRun)
+		}
+
+		logger.Info("waitForCallback: token expired, applying failurePolicy Fail",
 			logging.KeyWorkflowRun, req.Name, "step", cb.StepName)
-
-		failurePolicy := r.findStepFailurePolicy(ctx, workflowRun, cb.StepName)
-
 		if r.EventRecorder != nil {
 			r.EventRecorder.Eventf(workflowRun, nil, corev1.EventTypeWarning, "CallbackTimeout",
 				"CallbackTimeout", "Callback timeout for step %q", cb.StepName)
@@ -1362,18 +1329,6 @@ func (r *WorkflowRunReconciler) reconcilePendingCallback(ctx context.Context, re
 			workflowRun.Status.StepStatuses = make(map[string]ottoflowv1alpha1.StepStatus)
 		}
 		ss := workflowRun.Status.StepStatuses[cb.StepName]
-		workflowRun.Status.PendingCallback = nil
-
-		if failurePolicy == ottoflowv1alpha1.FailurePolicyContinue {
-			ss.Phase = ottoflowv1alpha1.StepPhaseSkipped
-			ss.Message = "Callback timed out; step skipped (failurePolicy: Continue)"
-			workflowRun.Status.StepStatuses[cb.StepName] = ss
-			if err := r.Status().Update(ctx, workflowRun); err != nil {
-				return ctrl.Result{}, false, err
-			}
-			return ctrl.Result{Requeue: true}, false, nil
-		}
-
 		ss.Phase = ottoflowv1alpha1.StepPhaseFailed
 		ss.Error = "callback timeout: no callback received within the configured timeout"
 		ss.Message = ss.Error
@@ -1396,22 +1351,77 @@ func (r *WorkflowRunReconciler) reconcilePendingCallback(ctx context.Context, re
 	return ctrl.Result{RequeueAfter: requeueIn + time.Second}, false, nil
 }
 
-// findStepFailurePolicy looks up the failurePolicy for a step by name in the referenced Workflow.
-// Returns FailurePolicyFail if the step is not found or has no policy set.
-func (r *WorkflowRunReconciler) findStepFailurePolicy(ctx context.Context, workflowRun *ottoflowv1alpha1.WorkflowRun, stepName string) string {
-	wfNamespace := workflowRun.Spec.WorkflowRef.Namespace
-	if wfNamespace == "" {
-		wfNamespace = workflowRun.Namespace
+// resumeRunnerJob recreates (or waits out) the runner Job so a paused WorkflowRun can resume after
+// a callback was delivered or a Continue failurePolicy applied on timeout. Both outcomes converge
+// on the same action: mark the run Running (so the recreated runner restores from checkpoint via
+// loadCheckpointIfNeeded instead of re-running completed steps) and proceed to Job creation.
+// PendingCallback is intentionally left set for the executor to consume.
+func (r *WorkflowRunReconciler) resumeRunnerJob(ctx context.Context, req ctrl.Request, workflow *ottoflowv1alpha1.Workflow, workflowRun *ottoflowv1alpha1.WorkflowRun) (ctrl.Result, bool, error) {
+	logger := log.FromContext(ctx)
+	cb := workflowRun.Status.PendingCallback
+	stepName := ""
+	if cb != nil {
+		stepName = cb.StepName
 	}
-	wf := &ottoflowv1alpha1.Workflow{}
-	if err := r.Get(ctx, types.NamespacedName{Namespace: wfNamespace, Name: workflowRun.Spec.WorkflowRef.Name}, wf); err != nil {
+
+	ensureRunning := func() (ctrl.Result, bool, error) {
+		if workflowRun.Status.Phase != ottoflowv1alpha1.WorkflowRunPhaseRunning {
+			workflowRun.Status.Phase = ottoflowv1alpha1.WorkflowRunPhaseRunning
+			if uErr := r.Status().Update(ctx, workflowRun); uErr != nil {
+				return ctrl.Result{}, false, uErr
+			}
+		}
+		return ctrl.Result{}, true, nil
+	}
+
+	jobName := workflowRunnerJobName(workflowRun.Name)
+	jobKey := types.NamespacedName{Name: jobName, Namespace: workflowRun.Namespace}
+	job := &batchv1.Job{}
+	err := r.Get(ctx, jobKey, job)
+	switch {
+	case apierrors.IsNotFound(err):
+		// Old paused Job gone (or none) — ready to resume.
+		return ensureRunning() // proceed → fall through to the creation block
+	case err != nil:
+		return ctrl.Result{}, false, err
+	case jobConditionTrue(job, batchv1.JobComplete) || job.Status.Succeeded > 0:
+		// Old paused runner Job exited 0 (Complete). Delete so we can recreate the same name.
+		// Checked before the failure case: a Job that succeeded after an earlier pod retry
+		// (backoffLimit>0) reports both Complete and Failed>0, and "completed" must win.
+		logger.Info("waitForCallback: recreating runner Job to resume",
+			logging.KeyWorkflowRun, req.Name, "step", stepName)
+		if job.DeletionTimestamp == nil {
+			if dErr := r.Delete(ctx, job, client.PropagationPolicy(metav1.DeletePropagationForeground)); dErr != nil && !apierrors.IsNotFound(dErr) {
+				logger.Error(dErr, "failed to delete old runner Job for callback resume")
+				return ctrl.Result{}, false, dErr
+			}
+		}
+		return ctrl.Result{RequeueAfter: 2 * time.Second}, false, nil
+	case jobConditionTrue(job, batchv1.JobFailed):
+		// A recreated resume Job terminally failed (backoffLimit exhausted). Gated on the
+		// JobFailed *condition*, not job.Status.Failed>0, so an in-flight retry is not misread
+		// as terminal failure. Route through the standard failure path (attempt cap + terminal
+		// fail) to avoid a hot delete/recreate loop.
+		res, _, hfErr := r.handleFailedJob(ctx, workflowRun, workflow, job, jobName)
+		return res, false, hfErr
+	default:
+		// Job exists and is still active ⇒ resume already in progress. Monitor.
+		return ensureRunning()
+	}
+}
+
+// findStepFailurePolicy looks up the failurePolicy for a step by name in the given Workflow.
+// Pure in-memory lookup: takes the already-resolved Workflow instead of re-fetching it, so it
+// respects whatever namespace resolution (including the ControllerNamespace fallback) the caller
+// used to obtain it. Returns FailurePolicyFail if workflow is nil, the step is not found, or the
+// step has no policy set.
+func findStepFailurePolicy(workflow *ottoflowv1alpha1.Workflow, stepName string) string {
+	if workflow == nil {
 		return ottoflowv1alpha1.FailurePolicyFail
 	}
-	for _, step := range wf.Spec.Steps {
-		if step.Name == stepName && step.WaitForCallback != nil {
-			if step.WaitForCallback.FailurePolicy != "" {
-				return step.WaitForCallback.FailurePolicy
-			}
+	for _, step := range workflow.Spec.Steps {
+		if step.Name == stepName && step.WaitForCallback != nil && step.WaitForCallback.FailurePolicy != "" {
+			return step.WaitForCallback.FailurePolicy
 		}
 	}
 	return ottoflowv1alpha1.FailurePolicyFail

--- a/internal/workflow/controller/workflowrun_controller_test.go
+++ b/internal/workflow/controller/workflowrun_controller_test.go
@@ -639,8 +639,11 @@ var _ = Describe("WorkflowRun Controller", func() {
 			reconciler := &WorkflowRunReconciler{Client: k8sClient, Scheme: k8sClient.Scheme(), RunnerConfig: RunnerConfig{RunnerClusterRole: "ottoflow-runner-role"}}
 
 			By("reconcile fails to resolve the Workflow and marks the run Failed")
+			// A NotFound Workflow reference is a terminal condition, not a transient one: the
+			// reconciler marks the run Failed and returns a nil error so controller-runtime does
+			// not keep re-queuing a run that can never succeed.
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: wrKey})
-			Expect(err).To(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			Expect(k8sClient.Get(ctx, wrKey, wr)).To(Succeed())
 			Expect(wr.Status.Phase).To(Equal(ottoflowv1alpha1.WorkflowRunPhaseFailed))

--- a/internal/workflow/controller/workflowrun_controller_test.go
+++ b/internal/workflow/controller/workflowrun_controller_test.go
@@ -8,7 +8,13 @@ that can be found in the LICENSE.md file.
 package controller
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -16,6 +22,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -29,6 +36,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	ottoflowv1alpha1 "github.com/nirmata/ottoflow/api/v1alpha1"
+	"github.com/nirmata/ottoflow/internal/workflow/executor"
+	"github.com/nirmata/ottoflow/internal/workflow/token"
 )
 
 const defaultNamespace = "default"
@@ -274,6 +283,368 @@ var _ = Describe("WorkflowRun Controller", func() {
 			Expect(wr.Status.Execution).NotTo(BeNil())
 			Expect(wr.Status.Execution.JobName).To(Equal("restart-fail-run-runner"))
 			Expect(wr.Status.Execution.Phase).To(Equal(string(ottoflowv1alpha1.WorkflowRunPhaseFailed)))
+		})
+	})
+
+	Context("waitForCallback resume", func() {
+		// This Context uses the real envtest API server (the shared package-level k8sClient),
+		// not the fake client, because the regression being guarded against only reproduces
+		// against real API-server Job status/finalizer semantics (see forceDeleteJob below).
+		ctx := context.Background()
+		ns := defaultNamespace
+
+		// checkpointCMNameForTest mirrors executor.checkpointConfigMapName (unexported) for
+		// the short, hyphen-only run names used in these tests, where no truncation or hash
+		// suffix is ever applied.
+		checkpointCMNameForTest := func(runName string) string {
+			return "ottoflow-cp-" + strings.ToLower(runName)
+		}
+
+		// forceDeleteJob works around envtest's lack of a garbage-collector controller. A
+		// foreground-propagation Delete sets a deletionTimestamp plus a "foregroundDeletion"
+		// finalizer that only a running GC controller would normally remove once dependent
+		// Pods are gone. Stripping the finalizer here simulates that cleanup completing so
+		// the object is actually removed and the run can be recreated under the same name.
+		forceDeleteJob := func(key types.NamespacedName) {
+			job := &batchv1.Job{}
+			if err := k8sClient.Get(ctx, key, job); err != nil {
+				Expect(errors.IsNotFound(err)).To(BeTrue())
+				return
+			}
+			if len(job.Finalizers) > 0 {
+				job.Finalizers = nil
+				Expect(k8sClient.Update(ctx, job)).To(Succeed())
+			}
+			if err := k8sClient.Get(ctx, key, job); err == nil {
+				if dErr := k8sClient.Delete(ctx, job, client.PropagationPolicy(metav1.DeletePropagationBackground)); dErr != nil && !errors.IsNotFound(dErr) {
+					GinkgoWriter.Printf("forceDeleteJob: delete error for %s: %v\n", key, dErr)
+				}
+			}
+			Eventually(func() bool {
+				getErr := k8sClient.Get(ctx, key, &batchv1.Job{})
+				if getErr != nil && !errors.IsNotFound(getErr) {
+					GinkgoWriter.Printf("forceDeleteJob: get error for %s: %v\n", key, getErr)
+				}
+				return errors.IsNotFound(getErr)
+			}, "5s", "100ms").Should(BeTrue())
+		}
+
+		buildWorkflowAndRun := func(wfName, runName string) (*ottoflowv1alpha1.Workflow, *ottoflowv1alpha1.WorkflowRun) {
+			workflow := &ottoflowv1alpha1.Workflow{
+				ObjectMeta: metav1.ObjectMeta{Name: wfName, Namespace: ns},
+				Spec: ottoflowv1alpha1.WorkflowSpec{
+					Steps: []ottoflowv1alpha1.Step{
+						{
+							Name:    "pre",
+							Outputs: []ottoflowv1alpha1.Output{{Name: "preResult", Expression: `"pre-done"`}},
+						},
+						{
+							Name:      "gate",
+							DependsOn: []string{"pre"},
+							WaitForCallback: &ottoflowv1alpha1.WaitForCallbackStep{
+								Timeout: "1h",
+								OutputSchema: &apiextensionsv1.JSON{
+									Raw: []byte(`{"type":"object","required":["approved"],"properties":{"approved":{"type":"boolean"}}}`),
+								},
+							},
+						},
+					},
+				},
+			}
+			wr := &ottoflowv1alpha1.WorkflowRun{
+				ObjectMeta: metav1.ObjectMeta{Name: runName, Namespace: ns},
+				Spec: ottoflowv1alpha1.WorkflowRunSpec{
+					WorkflowRef: ottoflowv1alpha1.WorkflowRef{Name: wfName, Namespace: ns},
+					Execution: &ottoflowv1alpha1.WorkflowRunExecutionSpec{
+						Checkpointing: &ottoflowv1alpha1.CheckpointingConfig{Enabled: true},
+					},
+				},
+			}
+			return workflow, wr
+		}
+
+		// writeCheckpoint persists a checkpoint ConfigMap in exactly the shape checkpoint.go
+		// expects, recording "pre" as already succeeded so a resumed runner would restore it
+		// instead of re-running it. WorkflowRunUID must match the created run's UID or Load
+		// treats it as a stale checkpoint and returns nil.
+		writeCheckpoint := func(runName string, runUID types.UID) {
+			snapshot := executor.CheckpointSnapshot{
+				Version:           1,
+				WorkflowRunUID:    string(runUID),
+				LastCompletedStep: "pre",
+				StepStatuses: map[string]ottoflowv1alpha1.StepStatus{
+					"pre": {Phase: ottoflowv1alpha1.StepPhaseSucceeded},
+				},
+				Context: map[string]interface{}{
+					"inputs":    map[string]interface{}{},
+					"variables": map[string]interface{}{"preResult": "pre-done"},
+					"steps":     map[string]interface{}{},
+				},
+			}
+			raw, err := json.Marshal(snapshot)
+			Expect(err).NotTo(HaveOccurred())
+			cmObj := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: checkpointCMNameForTest(runName), Namespace: ns},
+				Data:       map[string]string{"checkpoint": string(raw)},
+			}
+			Expect(k8sClient.Create(ctx, cmObj)).To(Succeed())
+		}
+
+		// markJobComplete simulates the paused runner Job having exited 0 (waitForCallback
+		// steps exit clean and wait for the controller to recreate the Job on resume).
+		markJobComplete := func(jobKey types.NamespacedName) {
+			job := &batchv1.Job{}
+			Expect(k8sClient.Get(ctx, jobKey, job)).To(Succeed())
+			now := metav1.Now()
+			job.Status.Conditions = []batchv1.JobCondition{
+				{Type: batchv1.JobComplete, Status: corev1.ConditionTrue, LastProbeTime: now, LastTransitionTime: now},
+			}
+			job.Status.Succeeded = 1
+			job.Status.StartTime = &now
+			job.Status.CompletionTime = &now
+			Expect(k8sClient.Status().Update(ctx, job)).To(Succeed())
+		}
+
+		cleanupAll := func(wfName, runName string) {
+			jobKey := types.NamespacedName{Name: workflowRunnerJobName(runName), Namespace: ns}
+			if err := k8sClient.Get(ctx, jobKey, &batchv1.Job{}); err == nil {
+				forceDeleteJob(jobKey)
+			}
+			_ = k8sClient.Delete(ctx, &ottoflowv1alpha1.WorkflowRun{ObjectMeta: metav1.ObjectMeta{Name: runName, Namespace: ns}})
+			_ = k8sClient.Delete(ctx, &ottoflowv1alpha1.Workflow{ObjectMeta: metav1.ObjectMeta{Name: wfName, Namespace: ns}})
+			_ = k8sClient.Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: checkpointCMNameForTest(runName), Namespace: ns}})
+		}
+
+		It("recreates the runner Job and preserves PendingCallback when outputs are delivered by a direct status update", func() {
+			wfName, runName := "cb-resume-wf-a", "cb-resume-run-a"
+			defer cleanupAll(wfName, runName)
+
+			workflow, wr := buildWorkflowAndRun(wfName, runName)
+			Expect(k8sClient.Create(ctx, workflow)).To(Succeed())
+			Expect(k8sClient.Create(ctx, wr)).To(Succeed())
+
+			wrKey := types.NamespacedName{Name: runName, Namespace: ns}
+			jobKey := types.NamespacedName{Name: workflowRunnerJobName(runName), Namespace: ns}
+			reconciler := &WorkflowRunReconciler{Client: k8sClient, Scheme: k8sClient.Scheme(), RunnerConfig: RunnerConfig{RunnerClusterRole: "ottoflow-runner-role"}}
+
+			By("initial reconcile creates the runner Job")
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: wrKey})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, wrKey, wr)).To(Succeed())
+			Expect(wr.Status.Phase).To(Equal(ottoflowv1alpha1.WorkflowRunPhasePending))
+			Expect(k8sClient.Get(ctx, jobKey, &batchv1.Job{})).To(Succeed())
+
+			By("simulating the pause: pending callback set, checkpoint written, old Job completed")
+			Expect(k8sClient.Get(ctx, wrKey, wr)).To(Succeed())
+			wr.Status.PendingCallback = &ottoflowv1alpha1.CallbackState{
+				TokenHash: token.HashToken(validTestToken()),
+				StepName:  "gate",
+				ExpiresAt: time.Now().Add(1 * time.Hour).Unix(),
+				CreatedAt: time.Now().Unix(),
+			}
+			Expect(k8sClient.Status().Update(ctx, wr)).To(Succeed())
+			writeCheckpoint(runName, wr.UID)
+			markJobComplete(jobKey)
+
+			By("delivering the callback outputs via a direct status update")
+			Expect(k8sClient.Get(ctx, wrKey, wr)).To(Succeed())
+			wr.Status.PendingCallback.Outputs = apiextensionsv1.JSON{Raw: []byte(`{"approved":true}`)}
+			Expect(k8sClient.Status().Update(ctx, wr)).To(Succeed())
+
+			By("reconcile deletes the old (completed) runner Job and requeues")
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: wrKey})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(2 * time.Second))
+
+			job := &batchv1.Job{}
+			getErr := k8sClient.Get(ctx, jobKey, job)
+			if getErr == nil {
+				Expect(job.DeletionTimestamp).NotTo(BeNil())
+			} else {
+				Expect(errors.IsNotFound(getErr)).To(BeTrue())
+			}
+
+			By("simulating garbage collection of the deleted Job (envtest has no GC controller)")
+			forceDeleteJob(jobKey)
+
+			By("reconcile recreates the runner Job and preserves PendingCallback for the executor to consume")
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: wrKey})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, jobKey, &batchv1.Job{})).To(Succeed())
+
+			Expect(k8sClient.Get(ctx, wrKey, wr)).To(Succeed())
+			Expect(wr.Status.Phase).To(Equal(ottoflowv1alpha1.WorkflowRunPhaseRunning))
+			Expect(wr.Status.PendingCallback).NotTo(BeNil())
+			Expect(wr.Status.PendingCallback.Outputs.Raw).NotTo(BeEmpty())
+
+			By("further reconciles converge: Job stays present, Phase stays Running, no repeated deletes")
+			for i := 0; i < 3; i++ {
+				_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: wrKey})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(k8sClient.Get(ctx, jobKey, &batchv1.Job{})).To(Succeed())
+				Expect(k8sClient.Get(ctx, wrKey, wr)).To(Succeed())
+				Expect(wr.Status.Phase).To(Equal(ottoflowv1alpha1.WorkflowRunPhaseRunning))
+			}
+		})
+
+		It("recreates the runner Job when outputs are delivered via the HTTP callback server", func() {
+			wfName, runName := "cb-resume-wf-b", "cb-resume-run-b"
+			defer cleanupAll(wfName, runName)
+
+			workflow, wr := buildWorkflowAndRun(wfName, runName)
+			Expect(k8sClient.Create(ctx, workflow)).To(Succeed())
+			Expect(k8sClient.Create(ctx, wr)).To(Succeed())
+
+			wrKey := types.NamespacedName{Name: runName, Namespace: ns}
+			jobKey := types.NamespacedName{Name: workflowRunnerJobName(runName), Namespace: ns}
+			reconciler := &WorkflowRunReconciler{Client: k8sClient, Scheme: k8sClient.Scheme(), RunnerConfig: RunnerConfig{RunnerClusterRole: "ottoflow-runner-role"}}
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: wrKey})
+			Expect(err).NotTo(HaveOccurred())
+
+			tok := validTestToken()
+			Expect(k8sClient.Get(ctx, wrKey, wr)).To(Succeed())
+			wr.Status.PendingCallback = &ottoflowv1alpha1.CallbackState{
+				TokenHash: token.HashToken(tok),
+				StepName:  "gate",
+				ExpiresAt: time.Now().Add(1 * time.Hour).Unix(),
+				CreatedAt: time.Now().Unix(),
+			}
+			Expect(k8sClient.Status().Update(ctx, wr)).To(Succeed())
+			writeCheckpoint(runName, wr.UID)
+			markJobComplete(jobKey)
+
+			By("delivering the callback outputs via the HTTP callback server")
+			cs := NewCallbackServer(k8sClient, nil, ":0")
+			path := fmt.Sprintf("/api/v1/workflow-runs/%s/%s/callback/%s", ns, runName, tok)
+			req := httptest.NewRequest(http.MethodPost, path, bytes.NewBufferString(`{"approved":true}`))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			cs.mux.ServeHTTP(w, req)
+			Expect(w.Code).To(Equal(http.StatusOK))
+
+			By("reconcile deletes the old (completed) runner Job and requeues")
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: wrKey})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(2 * time.Second))
+
+			forceDeleteJob(jobKey)
+
+			By("reconcile recreates the runner Job and preserves PendingCallback for the executor to consume")
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: wrKey})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, jobKey, &batchv1.Job{})).To(Succeed())
+
+			Expect(k8sClient.Get(ctx, wrKey, wr)).To(Succeed())
+			Expect(wr.Status.Phase).To(Equal(ottoflowv1alpha1.WorkflowRunPhaseRunning))
+			Expect(wr.Status.PendingCallback).NotTo(BeNil())
+			Expect(wr.Status.PendingCallback.Outputs.Raw).NotTo(BeEmpty())
+		})
+
+		It("terminally fails a resume run without leaving PendingCallback set when the recreated Job fails", func() {
+			wfName, runName := "cb-resume-wf-c", "cb-resume-run-c"
+			defer cleanupAll(wfName, runName)
+
+			workflow, wr := buildWorkflowAndRun(wfName, runName)
+			zeroRetries := int32(0)
+			wr.Spec.Execution.Checkpointing.MaxRestartAttempts = &zeroRetries
+			Expect(k8sClient.Create(ctx, workflow)).To(Succeed())
+			Expect(k8sClient.Create(ctx, wr)).To(Succeed())
+
+			wrKey := types.NamespacedName{Name: runName, Namespace: ns}
+			jobKey := types.NamespacedName{Name: workflowRunnerJobName(runName), Namespace: ns}
+			reconciler := &WorkflowRunReconciler{Client: k8sClient, Scheme: k8sClient.Scheme(), RunnerConfig: RunnerConfig{RunnerClusterRole: "ottoflow-runner-role"}}
+
+			By("initial reconcile creates the runner Job")
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: wrKey})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("simulating the pause: pending callback set, checkpoint written, old Job completed")
+			Expect(k8sClient.Get(ctx, wrKey, wr)).To(Succeed())
+			wr.Status.PendingCallback = &ottoflowv1alpha1.CallbackState{
+				TokenHash: token.HashToken(validTestToken()),
+				StepName:  "gate",
+				ExpiresAt: time.Now().Add(1 * time.Hour).Unix(),
+				CreatedAt: time.Now().Unix(),
+			}
+			Expect(k8sClient.Status().Update(ctx, wr)).To(Succeed())
+			writeCheckpoint(runName, wr.UID)
+			markJobComplete(jobKey)
+
+			By("delivering the callback outputs via a direct status update")
+			Expect(k8sClient.Get(ctx, wrKey, wr)).To(Succeed())
+			wr.Status.PendingCallback.Outputs = apiextensionsv1.JSON{Raw: []byte(`{"approved":true}`)}
+			Expect(k8sClient.Status().Update(ctx, wr)).To(Succeed())
+
+			By("reconcile deletes the old (completed) runner Job and requeues")
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: wrKey})
+			Expect(err).NotTo(HaveOccurred())
+			forceDeleteJob(jobKey)
+
+			By("reconcile recreates the runner Job and preserves PendingCallback for the executor to consume")
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: wrKey})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, wrKey, wr)).To(Succeed())
+			Expect(wr.Status.Phase).To(Equal(ottoflowv1alpha1.WorkflowRunPhaseRunning))
+			Expect(wr.Status.PendingCallback).NotTo(BeNil())
+
+			By("the recreated resume Job terminally fails (backoffLimit exhausted)")
+			job := &batchv1.Job{}
+			Expect(k8sClient.Get(ctx, jobKey, job)).To(Succeed())
+			now := metav1.Now()
+			job.Status.StartTime = &now
+			job.Status.Failed = 1
+			job.Status.Conditions = []batchv1.JobCondition{
+				{Type: batchv1.JobFailed, Status: corev1.ConditionTrue, LastTransitionTime: now},
+			}
+			Expect(k8sClient.Status().Update(ctx, job)).To(Succeed())
+
+			By("reconcile routes the failed resume Job through the terminal-failure path")
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: wrKey})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(k8sClient.Get(ctx, wrKey, wr)).To(Succeed())
+			Expect(wr.Status.Phase).To(Equal(ottoflowv1alpha1.WorkflowRunPhaseFailed))
+			Expect(wr.Status.PendingCallback).To(BeNil())
+		})
+
+		It("clears PendingCallback when the referenced Workflow cannot be resolved", func() {
+			wfName, runName := "cb-resolve-fail-wf", "cb-resolve-fail-run"
+			defer cleanupAll(wfName, runName)
+
+			// Deliberately do NOT create the Workflow so getReferencedWorkflow fails. This
+			// exercises the pre-gate failure path in reconcileJobExecution: a run carrying a live
+			// pending callback whose Workflow has been deleted must be marked Failed WITHOUT
+			// leaving a stale PendingCallback, or its callback endpoint would keep accepting POSTs
+			// for a dead run (the callback server never checks Phase).
+			wr := &ottoflowv1alpha1.WorkflowRun{
+				ObjectMeta: metav1.ObjectMeta{Name: runName, Namespace: ns},
+				Spec: ottoflowv1alpha1.WorkflowRunSpec{
+					WorkflowRef: ottoflowv1alpha1.WorkflowRef{Name: wfName, Namespace: ns},
+				},
+			}
+			Expect(k8sClient.Create(ctx, wr)).To(Succeed())
+
+			wrKey := types.NamespacedName{Name: runName, Namespace: ns}
+			By("setting a live pending callback on the run")
+			Expect(k8sClient.Get(ctx, wrKey, wr)).To(Succeed())
+			wr.Status.PendingCallback = &ottoflowv1alpha1.CallbackState{
+				TokenHash: token.HashToken(validTestToken()),
+				StepName:  "gate",
+				ExpiresAt: time.Now().Add(1 * time.Hour).Unix(),
+				CreatedAt: time.Now().Unix(),
+			}
+			Expect(k8sClient.Status().Update(ctx, wr)).To(Succeed())
+
+			reconciler := &WorkflowRunReconciler{Client: k8sClient, Scheme: k8sClient.Scheme(), RunnerConfig: RunnerConfig{RunnerClusterRole: "ottoflow-runner-role"}}
+
+			By("reconcile fails to resolve the Workflow and marks the run Failed")
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: wrKey})
+			Expect(err).To(HaveOccurred())
+
+			Expect(k8sClient.Get(ctx, wrKey, wr)).To(Succeed())
+			Expect(wr.Status.Phase).To(Equal(ottoflowv1alpha1.WorkflowRunPhaseFailed))
+			Expect(wr.Status.PendingCallback).To(BeNil())
 		})
 	})
 

--- a/internal/workflow/executor/checkpoint_test.go
+++ b/internal/workflow/executor/checkpoint_test.go
@@ -606,11 +606,11 @@ var _ = Describe("ExecuteWorkflow checkpoint restore", func() {
 		utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	})
 
-	buildCheckpointCM := func(ns, wfrName string, snap CheckpointSnapshot) *corev1.ConfigMap {
+	buildCheckpointCM := func(wfrName string, snap CheckpointSnapshot) *corev1.ConfigMap {
 		raw, err := json.Marshal(snap)
 		Expect(err).NotTo(HaveOccurred())
 		return &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{Name: checkpointConfigMapName(wfrName), Namespace: ns},
+			ObjectMeta: metav1.ObjectMeta{Name: checkpointConfigMapName(wfrName), Namespace: "default"},
 			Data:       map[string]string{"checkpoint": string(raw)},
 		}
 	}
@@ -629,7 +629,7 @@ var _ = Describe("ExecuteWorkflow checkpoint restore", func() {
 				"steps":     map[string]interface{}{},
 			},
 		}
-		cm := buildCheckpointCM("default", wfRunName, snapshot)
+		cm := buildCheckpointCM(wfRunName, snapshot)
 		k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
 
 		workflowRun := &ottoflowv1alpha1.WorkflowRun{
@@ -687,7 +687,7 @@ var _ = Describe("ExecuteWorkflow checkpoint restore", func() {
 				"steps":     map[string]interface{}{},
 			},
 		}
-		cm := buildCheckpointCM("default", wfRunName, snapshot)
+		cm := buildCheckpointCM(wfRunName, snapshot)
 		k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
 
 		workflowRun := &ottoflowv1alpha1.WorkflowRun{
@@ -807,5 +807,85 @@ var _ = Describe("ExecuteWorkflow checkpoint restore", func() {
 		Expect(outputs["apiToken"]).To(Equal(sensitiveRedactedPlaceholder))
 		vars := saved.Context["variables"].(map[string]interface{})
 		Expect(vars["v1"]).To(Equal("public-value"))
+	})
+
+	// These two cases call loadCheckpointIfNeeded directly (unexported, same package) rather
+	// than going through ExecuteWorkflow. They pin down the precondition the controller's
+	// waitForCallback resume fix depends on: setting Status.Phase=Running (with Attempts still
+	// 0, since a callback resume is not a restart-attempt retry) must be sufficient on its own
+	// to trigger a checkpoint restore when the runner Job is recreated after a callback.
+	It("loadCheckpointIfNeeded returns true and restores state when Phase is Running (post-callback resume)", func() {
+		snapshot := CheckpointSnapshot{
+			Version:           1,
+			WorkflowRunUID:    string(wfRunUID),
+			LastCompletedStep: "pre",
+			StepStatuses: map[string]ottoflowv1alpha1.StepStatus{
+				"pre": {Phase: ottoflowv1alpha1.StepPhaseSucceeded},
+			},
+			Context: map[string]interface{}{
+				"inputs":    map[string]interface{}{},
+				"variables": map[string]interface{}{"v1": "restored-running"},
+				"steps":     map[string]interface{}{},
+			},
+		}
+		cm := buildCheckpointCM(wfRunName, snapshot)
+		k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
+
+		workflowRun := &ottoflowv1alpha1.WorkflowRun{
+			ObjectMeta: metav1.ObjectMeta{Name: wfRunName, Namespace: "default", UID: wfRunUID},
+			Spec: ottoflowv1alpha1.WorkflowRunSpec{
+				WorkflowRef: ottoflowv1alpha1.WorkflowRef{Name: "wf"},
+				Execution: &ottoflowv1alpha1.WorkflowRunExecutionSpec{
+					Checkpointing: &ottoflowv1alpha1.CheckpointingConfig{Enabled: true},
+				},
+			},
+			// Attempts == 0 (default), but Phase == Running — exactly the state the controller
+			// now persists before recreating the runner Job to resume a waitForCallback step.
+			Status: ottoflowv1alpha1.WorkflowRunStatus{Phase: ottoflowv1alpha1.WorkflowRunPhaseRunning},
+		}
+
+		exec, err := NewWorkflowExecutorWithMetrics(k8sClient, nil, nil, nil, workflowRun, 0, 5, nil)
+		Expect(err).NotTo(HaveOccurred())
+		exec.SetCheckpointManager(NewCheckpointManager(k8sClient, workflowRun))
+
+		restored, err := exec.loadCheckpointIfNeeded(ctx, workflowRun)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(restored).To(BeTrue())
+		Expect(workflowRun.Status.StepStatuses["pre"].Phase).To(Equal(ottoflowv1alpha1.StepPhaseSucceeded))
+		ctx2, _ := exec.contextManager.ReadContext(ctx)
+		Expect(ctx2["variables"].(map[string]interface{})["v1"]).To(Equal("restored-running"))
+	})
+
+	It("loadCheckpointIfNeeded returns false when Phase is Pending and Attempts is 0, even if a checkpoint exists", func() {
+		snapshot := CheckpointSnapshot{
+			Version:        1,
+			WorkflowRunUID: string(wfRunUID),
+			StepStatuses: map[string]ottoflowv1alpha1.StepStatus{
+				"pre": {Phase: ottoflowv1alpha1.StepPhaseSucceeded},
+			},
+			Context: map[string]interface{}{},
+		}
+		cm := buildCheckpointCM(wfRunName, snapshot)
+		k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
+
+		workflowRun := &ottoflowv1alpha1.WorkflowRun{
+			ObjectMeta: metav1.ObjectMeta{Name: wfRunName, Namespace: "default", UID: wfRunUID},
+			Spec: ottoflowv1alpha1.WorkflowRunSpec{
+				WorkflowRef: ottoflowv1alpha1.WorkflowRef{Name: "wf"},
+				Execution: &ottoflowv1alpha1.WorkflowRunExecutionSpec{
+					Checkpointing: &ottoflowv1alpha1.CheckpointingConfig{Enabled: true},
+				},
+			},
+			Status: ottoflowv1alpha1.WorkflowRunStatus{Phase: ottoflowv1alpha1.WorkflowRunPhasePending},
+		}
+
+		exec, err := NewWorkflowExecutorWithMetrics(k8sClient, nil, nil, nil, workflowRun, 0, 5, nil)
+		Expect(err).NotTo(HaveOccurred())
+		exec.SetCheckpointManager(NewCheckpointManager(k8sClient, workflowRun))
+
+		restored, err := exec.loadCheckpointIfNeeded(ctx, workflowRun)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(restored).To(BeFalse())
+		Expect(workflowRun.Status.StepStatuses).To(BeEmpty())
 	})
 })


### PR DESCRIPTION
## Problem
A `WorkflowRun` that paused on a `waitForCallback` step never resumed after its callback was delivered. `reconcilePendingCallback` deleted the paused (completed) runner Job but never recreated one and never released the pending-callback guard, so every reconcile re-entered the same branch — an open loop with no termination state. `status.phase` stayed `Pending` indefinitely; because the outputs check runs before the timeout check, even the configured timeout became unreachable.

Fixes #18

## Fix
- `reconcilePendingCallback` now returns a `proceed` flag. When the callback outputs are present and the old Job is gone, the pending-callback guard falls through to the existing Job-creation path (reused, not duplicated) to recreate the runner.
- Persist `Phase = Running` before recreation so the new runner restores completed steps from checkpoint instead of re-executing them. `pendingCallback` is intentionally left set — the runner consumes the outputs, feeds them to the waiting step, then clears it.
- A crashed *resume* Job is routed through the existing `handleFailedJob` (attempt cap + terminal failure), gated on the `JobFailed` condition and ordered after the completion check, so a retried-then-succeeded Job isn't misclassified and there's no hot delete/recreate loop.
- Every transition to `Failed` now clears `pendingCallback`, so a terminated run (terminal resume failure, workflow-resolution failure, or runner-creation failure) can no longer accept callbacks on its endpoint.

## Tests
New controller tests cover both delivery paths (direct status patch + HTTP callback server): pause → deliver → assert runner Job recreated, `Phase = Running`, prior step output preserved; plus failure cases asserting `pendingCallback` is cleared when a run is marked `Failed`. Executor tests pin the checkpoint-restore precondition. No CRD/API change.

## Notes
- Safe resume requires `spec.execution.checkpointing.enabled: true`; with it off, resume re-executes pre-gate steps (docs caveat to follow).
- The callback *timeout* path has a related never-recreate flaw, left for a separate issue.
