### PR TITLE
feat(cli): add "ottoflow version" command to show build version details

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,6 +18,8 @@ builds:
     ldflags:
       - -s -w
       - -X github.com/nirmata/ottoflow/cli/cmd.version={{ .Version }}
+      - -X github.com/nirmata/ottoflow/cli/cmd.gitCommit={{ .ShortCommit }}
+      - -X github.com/nirmata/ottoflow/cli/cmd.buildTime={{ .Date }}
 
 archives:
   - id: ottoflow

--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ CLI_MAIN_PACKAGE=./cli/main.go
 CLI_VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 CLI_BUILD_TIME=$(shell date -u '+%Y-%m-%d_%H:%M:%S')
 CLI_GIT_COMMIT=$(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
-CLI_LDFLAGS=-ldflags "-X github.com/nirmata/ottoflow/cli/cmd.version=$(CLI_VERSION) -X main.buildTime=$(CLI_BUILD_TIME) -X main.gitCommit=$(CLI_GIT_COMMIT)"
+CLI_LDFLAGS=-ldflags "-X github.com/nirmata/ottoflow/cli/cmd.version=$(CLI_VERSION) -X github.com/nirmata/ottoflow/cli/cmd.buildTime=$(CLI_BUILD_TIME) -X github.com/nirmata/ottoflow/cli/cmd.gitCommit=$(CLI_GIT_COMMIT)"
 
 .PHONY: build-cli
 build-cli: manifests generate fmt vet ## Build CLI binary.

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -21,8 +21,12 @@ var (
 	kubeconfig string
 )
 
-// version is set at build time via ldflags (git describe --tags)
-var version = "dev"
+// version, gitCommit, and buildTime are set at build time via ldflags.
+var (
+	version   = "dev"
+	gitCommit = "unknown"
+	buildTime = "unknown"
+)
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -58,23 +58,21 @@ func getVersion(cmd *cobra.Command, args []string) error {
 		Platform:  fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
 	}
 
+	out := cmd.OutOrStdout()
 	switch versionOutputFormat {
 	case "json":
 		data, err := json.MarshalIndent(info, "", "  ")
 		if err != nil {
 			return fmt.Errorf("failed to marshal version info: %w", err)
 		}
-		fmt.Fprintln(cmd.OutOrStdout(), string(data))
+		_, err = fmt.Fprintln(out, string(data))
+		return err
 	case "table":
-		out := cmd.OutOrStdout()
-		fmt.Fprintf(out, "Version:    %s\n", info.Version)
-		fmt.Fprintf(out, "Git Commit: %s\n", info.GitCommit)
-		fmt.Fprintf(out, "Build Time: %s\n", info.BuildTime)
-		fmt.Fprintf(out, "Go Version: %s\n", info.GoVersion)
-		fmt.Fprintf(out, "Platform:   %s\n", info.Platform)
+		_, err := fmt.Fprintf(out,
+			"Version:    %s\nGit Commit: %s\nBuild Time: %s\nGo Version: %s\nPlatform:   %s\n",
+			info.Version, info.GitCommit, info.BuildTime, info.GoVersion, info.Platform)
+		return err
 	default:
 		return fmt.Errorf("unsupported output format: %s (must be table or json)", versionOutputFormat)
 	}
-
-	return nil
 }

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2026 Nirmata, Inc.
+
+Use of this source code is governed by the Business Source License 1.1
+that can be found in the LICENSE.md file.
+*/
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"runtime"
+
+	"github.com/spf13/cobra"
+)
+
+var versionOutputFormat string
+
+// buildInfo holds the build version details reported by the version command.
+type buildInfo struct {
+	Version   string `json:"version"`
+	GitCommit string `json:"gitCommit"`
+	BuildTime string `json:"buildTime"`
+	GoVersion string `json:"goVersion"`
+	Platform  string `json:"platform"`
+}
+
+// versionCmd represents the version command
+var versionCmd = &cobra.Command{
+	Use:          "version",
+	Short:        "Show CLI build version details",
+	SilenceUsage: true,
+	Long: `Show the OttoFlow CLI build version details, including the version,
+git commit, build time, Go version, and platform.
+
+Examples:
+  # Show build version details
+  ottoflow version
+
+  # Show build version details in JSON format
+  ottoflow version --output json`,
+	Args: cobra.NoArgs,
+	RunE: getVersion,
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+	versionCmd.Flags().StringVarP(&versionOutputFormat, "output", "o", "table", "Output format: table, json")
+}
+
+func getVersion(cmd *cobra.Command, args []string) error {
+	info := buildInfo{
+		Version:   version,
+		GitCommit: gitCommit,
+		BuildTime: buildTime,
+		GoVersion: runtime.Version(),
+		Platform:  fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+
+	switch versionOutputFormat {
+	case "json":
+		data, err := json.MarshalIndent(info, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal version info: %w", err)
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), string(data))
+	case "table":
+		out := cmd.OutOrStdout()
+		fmt.Fprintf(out, "Version:    %s\n", info.Version)
+		fmt.Fprintf(out, "Git Commit: %s\n", info.GitCommit)
+		fmt.Fprintf(out, "Build Time: %s\n", info.BuildTime)
+		fmt.Fprintf(out, "Go Version: %s\n", info.GoVersion)
+		fmt.Fprintf(out, "Platform:   %s\n", info.Platform)
+	default:
+		return fmt.Errorf("unsupported output format: %s (must be table or json)", versionOutputFormat)
+	}
+
+	return nil
+}

--- a/cli/cmd/version_test.go
+++ b/cli/cmd/version_test.go
@@ -14,23 +14,49 @@ import (
 	"testing"
 )
 
+// resetRootCmd snapshots the mutable global state these tests touch — the
+// version vars, the persistent --output flag, and rootCmd's args/writers — and
+// restores it when the test ends. versionOutputFormat is a persistent cobra flag
+// whose value survives across rootCmd.Execute() calls, so without this the tests
+// would be order-dependent (e.g. a prior --output json run leaking into a test
+// that omits --output) and would also pollute other cmd-package tests that drive
+// rootCmd.
+func resetRootCmd(t *testing.T) {
+	t.Helper()
+	oldV, oldC, oldB, oldFormat := version, gitCommit, buildTime, versionOutputFormat
+	t.Cleanup(func() {
+		version, gitCommit, buildTime, versionOutputFormat = oldV, oldC, oldB, oldFormat
+		rootCmd.SetArgs(nil)
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+	})
+}
+
 func TestVersionCommandTable(t *testing.T) {
-	oldVersion, oldCommit, oldBuildTime := version, gitCommit, buildTime
+	resetRootCmd(t)
 	version, gitCommit, buildTime = "v1.2.3", "abc1234", "2026-08-24_00:00:00"
-	defer func() { version, gitCommit, buildTime = oldVersion, oldCommit, oldBuildTime }()
 
 	buf := &bytes.Buffer{}
 	rootCmd.SetOut(buf)
 	rootCmd.SetErr(buf)
-	rootCmd.SetArgs([]string{"version"})
-	defer rootCmd.SetArgs(nil)
+	// Pass --output table explicitly rather than relying on the flag default:
+	// versionOutputFormat is a persistent flag, so being explicit keeps this test
+	// self-sufficient regardless of what ran before it.
+	rootCmd.SetArgs([]string{"version", "--output", "table"})
 
 	if err := rootCmd.Execute(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	out := buf.String()
-	for _, want := range []string{"Version:    v1.2.3", "Git Commit: abc1234", "Build Time: 2026-08-24_00:00:00", "Go Version:", "Platform:"} {
+	wants := []string{
+		"Version:    v1.2.3",
+		"Git Commit: abc1234",
+		"Build Time: 2026-08-24_00:00:00",
+		"Go Version:",
+		"Platform:",
+	}
+	for _, want := range wants {
 		if !strings.Contains(out, want) {
 			t.Errorf("expected output to contain %q, got:\n%s", want, out)
 		}
@@ -38,15 +64,13 @@ func TestVersionCommandTable(t *testing.T) {
 }
 
 func TestVersionCommandJSON(t *testing.T) {
-	oldVersion, oldCommit, oldBuildTime := version, gitCommit, buildTime
+	resetRootCmd(t)
 	version, gitCommit, buildTime = "v1.2.3", "abc1234", "2026-08-24_00:00:00"
-	defer func() { version, gitCommit, buildTime = oldVersion, oldCommit, oldBuildTime }()
 
 	buf := &bytes.Buffer{}
 	rootCmd.SetOut(buf)
 	rootCmd.SetErr(buf)
 	rootCmd.SetArgs([]string{"version", "--output", "json"})
-	defer rootCmd.SetArgs(nil)
 
 	if err := rootCmd.Execute(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -65,11 +89,12 @@ func TestVersionCommandJSON(t *testing.T) {
 }
 
 func TestVersionCommandInvalidOutputFormat(t *testing.T) {
+	resetRootCmd(t)
+
 	buf := &bytes.Buffer{}
 	rootCmd.SetOut(buf)
 	rootCmd.SetErr(buf)
 	rootCmd.SetArgs([]string{"version", "--output", "xml"})
-	defer rootCmd.SetArgs(nil)
 
 	if err := rootCmd.Execute(); err == nil {
 		t.Fatal("expected error for unsupported output format, got nil")

--- a/cli/cmd/version_test.go
+++ b/cli/cmd/version_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2026 Nirmata, Inc.
+
+Use of this source code is governed by the Business Source License 1.1
+that can be found in the LICENSE.md file.
+*/
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestVersionCommandTable(t *testing.T) {
+	oldVersion, oldCommit, oldBuildTime := version, gitCommit, buildTime
+	version, gitCommit, buildTime = "v1.2.3", "abc1234", "2026-08-24_00:00:00"
+	defer func() { version, gitCommit, buildTime = oldVersion, oldCommit, oldBuildTime }()
+
+	buf := &bytes.Buffer{}
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"version"})
+	defer rootCmd.SetArgs(nil)
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	for _, want := range []string{"Version:    v1.2.3", "Git Commit: abc1234", "Build Time: 2026-08-24_00:00:00", "Go Version:", "Platform:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected output to contain %q, got:\n%s", want, out)
+		}
+	}
+}
+
+func TestVersionCommandJSON(t *testing.T) {
+	oldVersion, oldCommit, oldBuildTime := version, gitCommit, buildTime
+	version, gitCommit, buildTime = "v1.2.3", "abc1234", "2026-08-24_00:00:00"
+	defer func() { version, gitCommit, buildTime = oldVersion, oldCommit, oldBuildTime }()
+
+	buf := &bytes.Buffer{}
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"version", "--output", "json"})
+	defer rootCmd.SetArgs(nil)
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var info buildInfo
+	if err := json.Unmarshal(buf.Bytes(), &info); err != nil {
+		t.Fatalf("failed to unmarshal JSON output: %v\noutput: %s", err, buf.String())
+	}
+	if info.Version != "v1.2.3" || info.GitCommit != "abc1234" || info.BuildTime != "2026-08-24_00:00:00" {
+		t.Errorf("unexpected build info: %+v", info)
+	}
+	if info.GoVersion == "" || info.Platform == "" {
+		t.Errorf("expected GoVersion and Platform to be populated: %+v", info)
+	}
+}
+
+func TestVersionCommandInvalidOutputFormat(t *testing.T) {
+	buf := &bytes.Buffer{}
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"version", "--output", "xml"})
+	defer rootCmd.SetArgs(nil)
+
+	if err := rootCmd.Execute(); err == nil {
+		t.Fatal("expected error for unsupported output format, got nil")
+	}
+}

--- a/docs/cli/ottoflow.md
+++ b/docs/cli/ottoflow.md
@@ -25,4 +25,5 @@ OttoFlow allows you to:
 * [ottoflow run](ottoflow_run.md)	 - Create and watch a WorkflowRun
 * [ottoflow status](ottoflow_status.md)	 - Get status of a workflow run
 * [ottoflow validate](ottoflow_validate.md)	 - Validate a Workflow definition without executing it
+* [ottoflow version](ottoflow_version.md)	 - Show CLI build version details
 

--- a/docs/cli/ottoflow_version.md
+++ b/docs/cli/ottoflow_version.md
@@ -1,0 +1,38 @@
+## ottoflow version
+
+Show CLI build version details
+
+### Synopsis
+
+Show the OttoFlow CLI build version details, including the version,
+git commit, build time, Go version, and platform.
+
+Examples:
+  # Show build version details
+  ottoflow version
+
+  # Show build version details in JSON format
+  ottoflow version --output json
+
+```
+ottoflow version [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for version
+  -o, --output string   Output format: table, json (default "table")
+```
+
+### Options inherited from parent commands
+
+```
+      --kubeconfig string   Path to kubeconfig file (defaults to $HOME/.kube/config)
+  -n, --namespace string    Kubernetes namespace (defaults to current kubeconfig context namespace, then "ottoflow")
+```
+
+### SEE ALSO
+
+* [ottoflow](ottoflow.md)	 - OttoFlow CLI - Execute and manage workflows
+


### PR DESCRIPTION
## Summary
- Add an `ottoflow version` subcommand that prints version, git commit, build time, Go version, and platform (`--output table` default, `--output json` supported).
- Fix `CLI_BUILD_TIME`/`CLI_GIT_COMMIT` ldflags in the `Makefile`, which previously targeted `main.buildTime`/`main.gitCommit` — symbols that don't exist — so those values were silently dropped. They now target `cli/cmd`, alongside the existing `version` var.
- Add matching ldflags to `.goreleaser.yaml` so released binaries carry git commit and build time too.
- Regenerate CLI docs (`docs/cli/ottoflow.md`, `docs/cli/ottoflow_version.md`) via `go test -tags gendocs`.

Fixes #36.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./cli/...`
- [x] `go test ./cli/...`
- [x] `make build-cli` then manually ran `./bin/ottoflow version` and `./bin/ottoflow version -o json` — confirmed real version/commit/build time are populated
- [x] `go test ./cli/cmd/... -tags gendocs -run TestGenerateCliDocs` to refresh CLI reference docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)