### PR TITLE
fix(executor,cli): fail zero-success forEach runs and check references in local validate

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -10,7 +10,7 @@ helm install ottoflow oci://ghcr.io/nirmata/ottoflow --version <version> -n otto
 
 ## Prerequisites
 
-- Kubernetes 1.20+
+- Kubernetes 1.29+
 
 ## Documentation
 

--- a/charts/ottoflow/README.md
+++ b/charts/ottoflow/README.md
@@ -4,7 +4,7 @@ This Helm chart installs [OttoFlow](https://github.com/nirmata/ottoflow) - Agent
 
 ## Prerequisites
 
-- Kubernetes 1.20+
+- Kubernetes 1.29+
 - Helm 3.0+
 - kubectl configured to access your cluster
 

--- a/cli/cmd/validate.go
+++ b/cli/cmd/validate.go
@@ -49,11 +49,15 @@ Checks performed:
   - Step expression-to-dependsOn alignment (MISSING_DEPENDS_ON)
   - Undefined inputs.* references (UNDEFINED_INPUT)
   - CEL expression syntax (compile-time, no evaluation)
-  - workflowRef, agentRef, stepTemplateRef (direct and forEach), and mcpToolCall.server
-    existence, checked against the cluster in cluster mode, or against the manifests loaded
-    from --workflow-dir in local mode; also checked for a loaded WorkflowRun's workflowRef.
-    NOTE: references declared inside an inline forEach.step are not statically resolved and
-    will only surface as a failure at run time.
+  - workflowRef, agentRef, stepTemplateRef (direct and forEach, plus one level into a
+    resolved template's own step), mcpToolCall.server, and the workflowRef/agentRef/
+    mcpToolCall.server declared inline on a forEach.step -- checked against the cluster in
+    cluster mode, or against the manifests loaded from --workflow-dir in local mode; also
+    checked for a loaded WorkflowRun's workflowRef.
+    In -f/--file mode, these are checked against every OttoFlow object found in the same
+    file (e.g. a Workflow plus its own StepTemplate/Agent/MCPServer), but an unresolved ref
+    is reported as a WARNING rather than a failure: a single file may legitimately reference
+    objects that are applied to the cluster separately and are not visible to this command.
 
 Examples:
   ottoflow validate --workflow-dir samples        # validate all workflows in directory
@@ -105,7 +109,7 @@ func runValidate(cmd *cobra.Command, args []string) error {
 		return runValidateDir(ctx, validateWorkflowDir)
 	}
 
-	wf, k8sClient, err := loadWorkflowForValidation(ctx, args)
+	wf, k8sClient, localExec, err := loadWorkflowForValidation(ctx, args)
 	if err != nil {
 		// A file holding only sibling OttoFlow resources (Agent, MCPServer, StepTemplate,
 		// WorkflowRun) has nothing for this command to check. Report and succeed: failing
@@ -137,7 +141,27 @@ func runValidate(cmd *cobra.Command, args []string) error {
 	}
 
 	errs := checkWorkflow(ctx, wf, k8sClient, celEnv, celEnvErr)
-	if len(errs) == 0 {
+
+	// WorkflowRun -> Workflow existence: only meaningful in local --workflow-dir mode, where
+	// localExec has every manifest from the directory loaded (see loadWorkflowForValidation).
+	// Runs regardless of whether a workflow name was given -- see checkWorkflowRunRefs's doc.
+	var runRefResults []workflowRunRefCheck
+	if localExec != nil {
+		runRefResults = checkWorkflowRunRefs(ctx, localExec)
+	}
+
+	// -f/--file mode: check the same references as Check 6, but against every OttoFlow
+	// object declared in the same file, and non-fatally -- a single file may legitimately
+	// reference objects applied to the cluster separately, which this command cannot see.
+	var fileWarnings []validationError
+	if validateFile != "" {
+		fileWarnings = fileRefWarnings(ctx, validateFile, wf)
+	}
+	for _, w := range fileWarnings {
+		fmt.Fprintf(os.Stderr, "WARNING [%-20s] step %q: %s\n", w.code, w.step, w.message)
+	}
+
+	if len(errs) == 0 && len(runRefResults) == 0 {
 		fmt.Printf("OK   workflow %q passed all checks\n", wf.Name)
 		if validateGenerateRBAC {
 			gen, err := clibac.New(clibac.Options{
@@ -157,6 +181,12 @@ func runValidate(cmd *cobra.Command, args []string) error {
 	}
 	for _, e := range errs {
 		fmt.Println(e.String())
+	}
+	for _, res := range runRefResults {
+		fmt.Printf("FAIL workflowRun %q\n", res.runName)
+		for _, e := range res.errs {
+			fmt.Printf("     %s\n", e.String())
+		}
 	}
 	os.Exit(1)
 	return nil
@@ -288,48 +318,143 @@ func checkWorkflow(
 	}
 
 	// Check 6: WorkflowRef, AgentRef, StepTemplateRef (direct and forEach), and
-	// MCPToolCall.server existence (only run when a control-plane client is available --
-	// cluster mode, or local --workflow-dir mode via the fake client the loader builds).
-	// References declared inside an inline step.ForEach.Step are NOT checked here -- see the
-	// validate command's Long help for that documented gap.
-	if k8sClient != nil {
-		seen := make(map[string]struct{})
-		for _, step := range wf.Spec.Steps {
-			for _, ref := range collectStepReferences(&step) {
-				refNS := ref.namespace
-				if refNS == "" {
-					refNS = wf.Namespace
-				}
-				dedupKey := ref.kind + "/" + refNS + "/" + ref.name
-				if _, ok := seen[dedupKey]; ok {
-					continue
-				}
-				seen[dedupKey] = struct{}{}
+	// MCPToolCall.server existence -- see checkStepRefs.
+	errs = append(errs, checkStepRefs(ctx, wf, k8sClient)...)
 
-				info, ok := refKinds[ref.kind]
-				if !ok {
-					// Unreachable given collectStepReferences only emits kinds present in
-					// refKinds, but fail loudly rather than silently skip a check if that
-					// ever changes.
-					errs = append(errs, validationError{code: "REF_NOT_FOUND", step: step.Name, message: fmt.Sprintf("internal error: unknown reference kind %q", ref.kind)})
+	return errs
+}
+
+// checkStepRefs is Check 6: it verifies every workflowRef, agentRef, stepTemplateRef (direct
+// and forEach), mcpToolCall.server, and forEach.step's own inline workflowRef/agentRef/
+// mcpToolCall.server actually resolves. Only runs when a control-plane client is available --
+// cluster mode, or local mode (--workflow-dir or -f) via the fake client the loader builds.
+//
+// For a stepTemplateRef that does resolve, it also checks -- one level deep, no further
+// recursion -- the referenced StepTemplate's own Spec.Step for the same three reference
+// kinds, so a shared template with a stale internal ref is caught even though the workflow
+// itself never names that ref directly. StepTemplateStep has no stepTemplateRef or forEach
+// field of its own, so there is nothing deeper to walk into.
+func checkStepRefs(ctx context.Context, wf *ottoflowv1alpha1.Workflow, k8sClient client.Client) []validationError {
+	var errs []validationError
+	if k8sClient == nil {
+		return errs
+	}
+
+	seen := make(map[string]struct{})
+	for _, step := range wf.Spec.Steps {
+		for _, ref := range collectStepReferences(&step) {
+			refNS := ref.namespace
+			if refNS == "" {
+				refNS = wf.Namespace
+			}
+			dedupKey := ref.kind + "/" + refNS + "/" + ref.name
+			if _, ok := seen[dedupKey]; ok {
+				continue
+			}
+			seen[dedupKey] = struct{}{}
+
+			obj, verr := resolveRef(ctx, k8sClient, ref.kind, ref.name, refNS)
+			if verr != nil {
+				verr.step = step.Name
+				errs = append(errs, *verr)
+				continue
+			}
+
+			tpl, ok := obj.(*ottoflowv1alpha1.StepTemplate)
+			if ref.kind != "StepTemplate" || !ok {
+				continue
+			}
+			for _, innerRef := range collectStepTemplateInnerRefs(tpl.Spec.Step) {
+				innerNS := innerRef.namespace
+				if innerNS == "" {
+					innerNS = wf.Namespace
+				}
+				innerKey := innerRef.kind + "/" + innerNS + "/" + innerRef.name
+				if _, ok := seen[innerKey]; ok {
 					continue
 				}
-				nn := types.NamespacedName{Namespace: refNS, Name: ref.name}
-				if getErr := k8sClient.Get(ctx, nn, info.newObj()); getErr != nil {
-					if apierrors.IsNotFound(getErr) {
-						errs = append(errs, validationError{
-							code:    "REF_NOT_FOUND",
-							step:    step.Name,
-							message: fmt.Sprintf("%s %q not found in namespace %q", info.label, ref.name, refNS),
-						})
-					}
+				seen[innerKey] = struct{}{}
+
+				if _, verr := resolveRef(ctx, k8sClient, innerRef.kind, innerRef.name, innerNS); verr != nil {
+					verr.step = step.Name
+					verr.message = fmt.Sprintf("%s (via stepTemplate %q)", verr.message, tpl.Name)
+					errs = append(errs, *verr)
 				}
 			}
 		}
 	}
-
 	return errs
 }
+
+// resolveRef looks up the object identified by kind/name/namespace using k8sClient. It
+// returns the resolved object on success, or a validationError to report: REF_NOT_FOUND for
+// a missing object, or REF_CHECK_ERROR for any other Get failure (an RBAC denial in cluster
+// mode, for instance) -- a case the caller must surface rather than silently treat as "ref
+// resolved fine". The returned validationError has no step set; the caller fills it in.
+func resolveRef(
+	ctx context.Context, k8sClient client.Client, kind, name, namespace string,
+) (client.Object, *validationError) {
+	info, ok := refKinds[kind]
+	if !ok {
+		// Unreachable given collectStepReferences/collectStepTemplateInnerRefs only emit
+		// kinds present in refKinds, but fail loudly rather than silently skip a check if
+		// that ever changes.
+		return nil, &validationError{
+			code:    "REF_NOT_FOUND",
+			message: fmt.Sprintf("internal error: unknown reference kind %q", kind),
+		}
+	}
+	obj := info.newObj()
+	nn := types.NamespacedName{Namespace: namespace, Name: name}
+	if getErr := k8sClient.Get(ctx, nn, obj); getErr != nil {
+		if apierrors.IsNotFound(getErr) {
+			return nil, &validationError{
+				code:    "REF_NOT_FOUND",
+				message: fmt.Sprintf("%s %q not found in namespace %q", info.label, name, namespace),
+			}
+		}
+		return nil, &validationError{
+			code:    "REF_CHECK_ERROR",
+			message: fmt.Sprintf("%s %q: error checking existence in namespace %q: %v", info.label, name, namespace, getErr),
+		}
+	}
+	return obj, nil
+}
+
+// fileRefWarnings runs checkStepRefs against wf using every OttoFlow object found in the
+// same -f file (a self-contained file may hold the Workflow plus its own StepTemplate,
+// Agent, and/or MCPServer). Parses filePath independently of loadWorkflowFromFile: that
+// function only extracts the Workflow document and intentionally ignores sibling kinds. A
+// read or parse failure here is not reported -- loadWorkflowFromFile already succeeded
+// reading and parsing the Workflow out of this same file, so this is best-effort only.
+func fileRefWarnings(ctx context.Context, filePath string, wf *ottoflowv1alpha1.Workflow) []validationError {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil
+	}
+	exec := cliexec.NewLocalWorkflowExecutor(nil, "", 0, "", "")
+	if err := exec.LoadFromReader(strings.NewReader(string(data))); err != nil {
+		return nil
+	}
+
+	// checkStepRefs defaults an unset ref namespace to wf.Namespace. loadWorkflowFromFile
+	// (which produced wf) does not default an empty metadata.namespace the way LoadFromReader
+	// does for every object it loads into exec's control client -- so a namespace-less
+	// Workflow must be checked as if it were in "default" here too, or every unqualified ref
+	// in it would look up namespace "" against objects the loader filed under "default" and
+	// come back as false REF_NOT_FOUND warnings.
+	refWF := wf
+	if wf.Namespace == "" {
+		cp := *wf
+		cp.Namespace = fileRefDefaultNamespace
+		refWF = &cp
+	}
+	return checkStepRefs(ctx, refWF, exec.ControlClient())
+}
+
+// fileRefDefaultNamespace mirrors cliexec's own (unexported) default: every object
+// LoadFromReader loads with no declared namespace is filed under "default".
+const fileRefDefaultNamespace = "default"
 
 // workflowRunRefCheck is one WorkflowRun's static ref-check result: the run's own name, plus
 // any validationErrors found (currently only REF_NOT_FOUND against workflowRef).
@@ -351,30 +476,28 @@ type workflowRunRefCheck struct {
 func checkWorkflowRunRefs(ctx context.Context, exec *cliexec.LocalWorkflowExecutor) []workflowRunRefCheck {
 	var results []workflowRunRefCheck
 	for _, lr := range exec.ListWorkflowRuns() {
-		var wf ottoflowv1alpha1.Workflow
 		wfName := lr.Run.Spec.WorkflowRef.Name
-		key := types.NamespacedName{Namespace: lr.ResolvedNamespace, Name: wfName}
-		if err := exec.ControlClient().Get(ctx, key, &wf); err != nil {
-			if apierrors.IsNotFound(err) {
-				results = append(results, workflowRunRefCheck{
-					runName: lr.Run.Name,
-					errs: []validationError{{
-						code:    "REF_NOT_FOUND",
-						message: fmt.Sprintf("workflowRef %q not found in namespace %q", wfName, lr.ResolvedNamespace),
-					}},
-				})
-			}
+		if _, verr := resolveRef(ctx, exec.ControlClient(), "Workflow", wfName, lr.ResolvedNamespace); verr != nil {
+			results = append(results, workflowRunRefCheck{
+				runName: lr.Run.Name,
+				errs:    []validationError{*verr},
+			})
 		}
 	}
 	return results
 }
 
-// loadWorkflowForValidation loads a Workflow from file, directory, or cluster.
-// Returns nil k8sClient when loading locally (no cluster checks will be run).
-func loadWorkflowForValidation(ctx context.Context, args []string) (*ottoflowv1alpha1.Workflow, client.Client, error) {
+// loadWorkflowForValidation loads a Workflow from file, directory, or cluster. Returns nil
+// k8sClient when loading locally from -f (no cluster checks will be run for that path; see
+// fileRefWarnings for the -f-specific ref checks). Returns a non-nil localExec only for
+// --workflow-dir mode -- callers use it to also run checkWorkflowRunRefs, since that exec has
+// every manifest in the directory loaded, not just the named workflow.
+func loadWorkflowForValidation(
+	ctx context.Context, args []string,
+) (*ottoflowv1alpha1.Workflow, client.Client, *cliexec.LocalWorkflowExecutor, error) {
 	if validateFile != "" {
 		wf, err := loadWorkflowFromFile(validateFile)
-		return wf, nil, err
+		return wf, nil, nil, err
 	}
 
 	if validateWorkflowDir != "" {
@@ -384,29 +507,29 @@ func loadWorkflowForValidation(ctx context.Context, args []string) (*ottoflowv1a
 		}
 		exec := cliexec.NewLocalWorkflowExecutor(nil, "", 0, "", "")
 		if err := exec.LoadFromDirectory(validateWorkflowDir); err != nil {
-			return nil, nil, fmt.Errorf("load workflow dir: %w", err)
+			return nil, nil, nil, fmt.Errorf("load workflow dir: %w", err)
 		}
 		wf, err := exec.GetWorkflow(ctx, name, getNamespace())
-		return wf, exec.ControlClient(), err
+		return wf, exec.ControlClient(), exec, err
 	}
 
 	// Cluster mode.
 	if len(args) == 0 {
-		return nil, nil, fmt.Errorf("workflow name required (or use --file / --workflow-dir for local validation)")
+		return nil, nil, nil, fmt.Errorf("workflow name required (or use --file / --workflow-dir for local validation)")
 	}
 	config, err := getKubeConfig()
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get kubeconfig: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to get kubeconfig: %w", err)
 	}
 	k8sClient, err := createK8sClient(config)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create Kubernetes client: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to create Kubernetes client: %w", err)
 	}
 	var wf ottoflowv1alpha1.Workflow
 	if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: getNamespace(), Name: args[0]}, &wf); err != nil {
-		return nil, nil, fmt.Errorf("get workflow %q: %w", args[0], err)
+		return nil, nil, nil, fmt.Errorf("get workflow %q: %w", args[0], err)
 	}
-	return &wf, k8sClient, nil
+	return &wf, k8sClient, nil, nil
 }
 
 // generateRBACBytes generates RBAC manifests for wf using gen and returns the YAML bytes.
@@ -522,9 +645,10 @@ type stepRef struct {
 
 // collectStepReferences returns every reference declaration on step that names another
 // OttoFlow CRD by kind/name/namespace: workflowRef, agentRef, the direct stepTemplateRef step
-// type, forEach.stepTemplateRef, and mcpToolCall.server. References declared inside an inline
-// step.ForEach.Step are intentionally NOT collected -- they are only known once the forEach's
-// items expression is evaluated at run time, so they cannot be statically resolved here.
+// type, forEach.stepTemplateRef, forEach.step's own inline workflowRef/agentRef/
+// mcpToolCall.server, and mcpToolCall.server. All of these are static names known without
+// evaluating any CEL expression (in particular, without evaluating the forEach's items
+// expression), so all of them can be resolved here.
 func collectStepReferences(step *ottoflowv1alpha1.Step) []stepRef {
 	var refs []stepRef
 	if step.WorkflowRef != nil && step.WorkflowRef.Name != "" {
@@ -540,10 +664,51 @@ func collectStepReferences(step *ottoflowv1alpha1.Step) []stepRef {
 		if tplRef := step.ForEach.StepTemplateRef; tplRef != nil && tplRef.Name != "" {
 			refs = append(refs, stepRef{kind: "StepTemplate", name: tplRef.Name, namespace: tplRef.Namespace})
 		}
+		if fes := step.ForEach.Step; fes != nil {
+			refs = append(refs, collectForEachStepReferences(fes)...)
+		}
 	}
 	if step.MCPToolCall != nil && step.MCPToolCall.Server != "" {
 		// server is a bare name with no namespace field of its own; it always defers to wf.Namespace.
 		refs = append(refs, stepRef{kind: "MCPServer", name: step.MCPToolCall.Server})
+	}
+	return refs
+}
+
+// collectForEachStepReferences returns the workflowRef/agentRef/mcpToolCall.server
+// references declared on an inline forEach.step. These are static names -- exactly like
+// forEach.stepTemplateRef, already checked above -- so they can be resolved without
+// evaluating the forEach's items expression.
+func collectForEachStepReferences(fes *ottoflowv1alpha1.StepForEachStep) []stepRef {
+	var refs []stepRef
+	if fes.WorkflowRef != nil && fes.WorkflowRef.Name != "" {
+		refs = append(refs, stepRef{kind: "Workflow", name: fes.WorkflowRef.Name, namespace: fes.WorkflowRef.Namespace})
+	}
+	if fes.AgentRef != nil && fes.AgentRef.Name != "" {
+		refs = append(refs, stepRef{kind: "Agent", name: fes.AgentRef.Name, namespace: fes.AgentRef.Namespace})
+	}
+	if fes.MCPToolCall != nil && fes.MCPToolCall.Server != "" {
+		refs = append(refs, stepRef{kind: "MCPServer", name: fes.MCPToolCall.Server})
+	}
+	return refs
+}
+
+// collectStepTemplateInnerRefs returns the workflowRef/agentRef/mcpToolCall.server
+// references declared on a StepTemplate's own Spec.Step -- used by checkStepRefs to check
+// one level into a resolved stepTemplateRef. A StepTemplateStep has no stepTemplateRef or
+// forEach field of its own, so this never needs to recurse any further.
+func collectStepTemplateInnerRefs(tplStep ottoflowv1alpha1.StepTemplateStep) []stepRef {
+	var refs []stepRef
+	if tplStep.WorkflowRef != nil && tplStep.WorkflowRef.Name != "" {
+		refs = append(refs, stepRef{
+			kind: "Workflow", name: tplStep.WorkflowRef.Name, namespace: tplStep.WorkflowRef.Namespace,
+		})
+	}
+	if tplStep.AgentRef != nil && tplStep.AgentRef.Name != "" {
+		refs = append(refs, stepRef{kind: "Agent", name: tplStep.AgentRef.Name, namespace: tplStep.AgentRef.Namespace})
+	}
+	if tplStep.MCPToolCall != nil && tplStep.MCPToolCall.Server != "" {
+		refs = append(refs, stepRef{kind: "MCPServer", name: tplStep.MCPToolCall.Server})
 	}
 	return refs
 }

--- a/cli/cmd/validate.go
+++ b/cli/cmd/validate.go
@@ -49,7 +49,11 @@ Checks performed:
   - Step expression-to-dependsOn alignment (MISSING_DEPENDS_ON)
   - Undefined inputs.* references (UNDEFINED_INPUT)
   - CEL expression syntax (compile-time, no evaluation)
-  - WorkflowRef and AgentRef existence (when connected to a cluster)
+  - workflowRef, agentRef, stepTemplateRef (direct and forEach), and mcpToolCall.server
+    existence, checked against the cluster in cluster mode, or against the manifests loaded
+    from --workflow-dir in local mode; also checked for a loaded WorkflowRun's workflowRef.
+    NOTE: references declared inside an inline forEach.step are not statically resolved and
+    will only surface as a failure at run time.
 
 Examples:
   ottoflow validate --workflow-dir samples        # validate all workflows in directory
@@ -185,7 +189,7 @@ func runValidateDir(ctx context.Context, dir string) error {
 
 	anyFailed := false
 	for _, wf := range workflows {
-		errs := checkWorkflow(ctx, wf, nil, celEnv, celEnvErr)
+		errs := checkWorkflow(ctx, wf, exec.ControlClient(), celEnv, celEnvErr)
 		if len(errs) == 0 {
 			fmt.Printf("OK   workflow %q passed all checks\n", wf.Name)
 		} else {
@@ -196,6 +200,18 @@ func runValidateDir(ctx context.Context, dir string) error {
 			}
 		}
 	}
+
+	// WorkflowRun -> Workflow existence: a WorkflowRun whose workflowRef names a Workflow
+	// that was not loaded (typo, wrong namespace, missing file) will fail at run time even
+	// though checkWorkflow above never sees it -- it only walks loaded Workflow steps.
+	for _, res := range checkWorkflowRunRefs(ctx, exec) {
+		anyFailed = true
+		fmt.Printf("FAIL workflowRun %q\n", res.runName)
+		for _, e := range res.errs {
+			fmt.Printf("     %s\n", e.String())
+		}
+	}
+
 	if anyFailed {
 		os.Exit(1)
 	}
@@ -271,49 +287,40 @@ func checkWorkflow(
 		}
 	}
 
-	// Check 6: WorkflowRef and AgentRef existence (cluster mode only).
+	// Check 6: WorkflowRef, AgentRef, StepTemplateRef (direct and forEach), and
+	// MCPToolCall.server existence (only run when a control-plane client is available --
+	// cluster mode, or local --workflow-dir mode via the fake client the loader builds).
+	// References declared inside an inline step.ForEach.Step are NOT checked here -- see the
+	// validate command's Long help for that documented gap.
 	if k8sClient != nil {
-		ns := getNamespace()
 		seen := make(map[string]struct{})
 		for _, step := range wf.Spec.Steps {
-			if step.WorkflowRef != nil && step.WorkflowRef.Name != "" {
-				key := "wf/" + step.WorkflowRef.Name
-				if _, ok := seen[key]; !ok {
-					seen[key] = struct{}{}
-					var ref ottoflowv1alpha1.Workflow
-					refNS := step.WorkflowRef.Namespace
-					if refNS == "" {
-						refNS = ns
-					}
-					nn := types.NamespacedName{Namespace: refNS, Name: step.WorkflowRef.Name}
-					if err := k8sClient.Get(ctx, nn, &ref); err != nil {
-						if apierrors.IsNotFound(err) {
-							errs = append(errs, validationError{
-								code:    "REF_NOT_FOUND",
-								step:    step.Name,
-								message: fmt.Sprintf("workflowRef %q not found in namespace %q", step.WorkflowRef.Name, refNS),
-							})
-						}
-					}
+			for _, ref := range collectStepReferences(&step) {
+				refNS := ref.namespace
+				if refNS == "" {
+					refNS = wf.Namespace
 				}
-			}
-			if step.AgentRef != nil && step.AgentRef.Name != "" {
-				key := "agent/" + step.AgentRef.Name
-				if _, ok := seen[key]; !ok {
-					seen[key] = struct{}{}
-					var ref ottoflowv1alpha1.Agent
-					refNS := step.AgentRef.Namespace
-					if refNS == "" {
-						refNS = ns
-					}
-					if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: refNS, Name: step.AgentRef.Name}, &ref); err != nil {
-						if apierrors.IsNotFound(err) {
-							errs = append(errs, validationError{
-								code:    "REF_NOT_FOUND",
-								step:    step.Name,
-								message: fmt.Sprintf("agentRef %q not found in namespace %q", step.AgentRef.Name, refNS),
-							})
-						}
+				dedupKey := ref.kind + "/" + refNS + "/" + ref.name
+				if _, ok := seen[dedupKey]; ok {
+					continue
+				}
+				seen[dedupKey] = struct{}{}
+
+				obj, err := newRefObject(ref.kind)
+				if err != nil {
+					// Unreachable given collectStepReferences only emits known kinds, but
+					// fail loudly rather than silently skip a check if that ever changes.
+					errs = append(errs, validationError{code: "REF_NOT_FOUND", step: step.Name, message: err.Error()})
+					continue
+				}
+				nn := types.NamespacedName{Namespace: refNS, Name: ref.name}
+				if getErr := k8sClient.Get(ctx, nn, obj); getErr != nil {
+					if apierrors.IsNotFound(getErr) {
+						errs = append(errs, validationError{
+							code:    "REF_NOT_FOUND",
+							step:    step.Name,
+							message: fmt.Sprintf("%s %q not found in namespace %q", refLabel(ref.kind), ref.name, refNS),
+						})
 					}
 				}
 			}
@@ -321,6 +328,44 @@ func checkWorkflow(
 	}
 
 	return errs
+}
+
+// workflowRunRefCheck is one WorkflowRun's static ref-check result: the run's own name, plus
+// any validationErrors found (currently only REF_NOT_FOUND against workflowRef).
+type workflowRunRefCheck struct {
+	runName string
+	errs    []validationError
+}
+
+// checkWorkflowRunRefs verifies every WorkflowRun exec loaded has a workflowRef that resolves
+// to a Workflow exec also loaded. This is a separate pass from checkWorkflow because
+// checkWorkflow only ever walks a loaded Workflow's own steps -- it never sees a WorkflowRun
+// whose workflowRef names a Workflow that was not loaded at all (typo, wrong namespace,
+// missing file), which would otherwise only fail at run time.
+//
+// Uses each run's ResolvedNamespace, not lr.Run.Namespace: indexWorkflowRuns force-defaults
+// the latter to "default" for any run that declared no namespace anywhere, which would
+// misreport a run the loader actually rebound into the Workflow's real namespace (e.g.
+// "ottoflow") as broken.
+func checkWorkflowRunRefs(ctx context.Context, exec *cliexec.LocalWorkflowExecutor) []workflowRunRefCheck {
+	var results []workflowRunRefCheck
+	for _, lr := range exec.ListWorkflowRuns() {
+		var wf ottoflowv1alpha1.Workflow
+		wfName := lr.Run.Spec.WorkflowRef.Name
+		key := types.NamespacedName{Namespace: lr.ResolvedNamespace, Name: wfName}
+		if err := exec.ControlClient().Get(ctx, key, &wf); err != nil {
+			if apierrors.IsNotFound(err) {
+				results = append(results, workflowRunRefCheck{
+					runName: lr.Run.Name,
+					errs: []validationError{{
+						code:    "REF_NOT_FOUND",
+						message: fmt.Sprintf("workflowRef %q not found in namespace %q", wfName, lr.ResolvedNamespace),
+					}},
+				})
+			}
+		}
+	}
+	return results
 }
 
 // loadWorkflowForValidation loads a Workflow from file, directory, or cluster.
@@ -341,7 +386,7 @@ func loadWorkflowForValidation(ctx context.Context, args []string) (*ottoflowv1a
 			return nil, nil, fmt.Errorf("load workflow dir: %w", err)
 		}
 		wf, err := exec.GetWorkflow(ctx, name, getNamespace())
-		return wf, nil, err
+		return wf, exec.ControlClient(), err
 	}
 
 	// Cluster mode.
@@ -464,6 +509,75 @@ func loadWorkflowFromFile(filePath string) (*ottoflowv1alpha1.Workflow, error) {
 	}
 	sort.Strings(otherKinds)
 	return nil, &noWorkflowInFileError{path: filePath, otherKinds: otherKinds, parseErr: firstParseErr}
+}
+
+// stepRef identifies one static reference a step makes to another OttoFlow CRD, discovered
+// so checkWorkflow's Check 6 can verify the referenced object actually exists.
+type stepRef struct {
+	kind      string // "Workflow", "Agent", "StepTemplate", or "MCPServer"
+	name      string
+	namespace string // as declared on the reference itself; "" means "defer to wf.Namespace"
+}
+
+// collectStepReferences returns every reference declaration on step that names another
+// OttoFlow CRD by kind/name/namespace: workflowRef, agentRef, the direct stepTemplateRef step
+// type, forEach.stepTemplateRef, and mcpToolCall.server. References declared inside an inline
+// step.ForEach.Step are intentionally NOT collected -- they are only known once the forEach's
+// items expression is evaluated at run time, so they cannot be statically resolved here.
+func collectStepReferences(step *ottoflowv1alpha1.Step) []stepRef {
+	var refs []stepRef
+	if step.WorkflowRef != nil && step.WorkflowRef.Name != "" {
+		refs = append(refs, stepRef{kind: "Workflow", name: step.WorkflowRef.Name, namespace: step.WorkflowRef.Namespace})
+	}
+	if step.AgentRef != nil && step.AgentRef.Name != "" {
+		refs = append(refs, stepRef{kind: "Agent", name: step.AgentRef.Name, namespace: step.AgentRef.Namespace})
+	}
+	if tplRef := step.StepTemplateRef; tplRef != nil && tplRef.Name != "" {
+		refs = append(refs, stepRef{kind: "StepTemplate", name: tplRef.Name, namespace: tplRef.Namespace})
+	}
+	if step.ForEach != nil {
+		if tplRef := step.ForEach.StepTemplateRef; tplRef != nil && tplRef.Name != "" {
+			refs = append(refs, stepRef{kind: "StepTemplate", name: tplRef.Name, namespace: tplRef.Namespace})
+		}
+	}
+	if step.MCPToolCall != nil && step.MCPToolCall.Server != "" {
+		// server is a bare name with no namespace field of its own; it always defers to wf.Namespace.
+		refs = append(refs, stepRef{kind: "MCPServer", name: step.MCPToolCall.Server})
+	}
+	return refs
+}
+
+// refLabel returns the field name to show in a validationError message for one reference kind.
+func refLabel(kind string) string {
+	switch kind {
+	case "Workflow":
+		return "workflowRef"
+	case "Agent":
+		return "agentRef"
+	case "StepTemplate":
+		return "stepTemplateRef"
+	case "MCPServer":
+		return "mcpToolCall.server"
+	default:
+		return kind
+	}
+}
+
+// newRefObject returns a zero-value typed client.Object for kind, so k8sClient.Get can decode
+// into the correct CRD type. kind must be one collectStepReferences emits.
+func newRefObject(kind string) (client.Object, error) {
+	switch kind {
+	case "Workflow":
+		return &ottoflowv1alpha1.Workflow{}, nil
+	case "Agent":
+		return &ottoflowv1alpha1.Agent{}, nil
+	case "StepTemplate":
+		return &ottoflowv1alpha1.StepTemplate{}, nil
+	case "MCPServer":
+		return &ottoflowv1alpha1.MCPServer{}, nil
+	default:
+		return nil, fmt.Errorf("internal error: unknown reference kind %q", kind)
+	}
 }
 
 // collectCELExpressions returns only the fields of a step that are definitively CEL

--- a/cli/cmd/validate.go
+++ b/cli/cmd/validate.go
@@ -306,20 +306,21 @@ func checkWorkflow(
 				}
 				seen[dedupKey] = struct{}{}
 
-				obj, err := newRefObject(ref.kind)
-				if err != nil {
-					// Unreachable given collectStepReferences only emits known kinds, but
-					// fail loudly rather than silently skip a check if that ever changes.
-					errs = append(errs, validationError{code: "REF_NOT_FOUND", step: step.Name, message: err.Error()})
+				info, ok := refKinds[ref.kind]
+				if !ok {
+					// Unreachable given collectStepReferences only emits kinds present in
+					// refKinds, but fail loudly rather than silently skip a check if that
+					// ever changes.
+					errs = append(errs, validationError{code: "REF_NOT_FOUND", step: step.Name, message: fmt.Sprintf("internal error: unknown reference kind %q", ref.kind)})
 					continue
 				}
 				nn := types.NamespacedName{Namespace: refNS, Name: ref.name}
-				if getErr := k8sClient.Get(ctx, nn, obj); getErr != nil {
+				if getErr := k8sClient.Get(ctx, nn, info.newObj()); getErr != nil {
 					if apierrors.IsNotFound(getErr) {
 						errs = append(errs, validationError{
 							code:    "REF_NOT_FOUND",
 							step:    step.Name,
-							message: fmt.Sprintf("%s %q not found in namespace %q", refLabel(ref.kind), ref.name, refNS),
+							message: fmt.Sprintf("%s %q not found in namespace %q", info.label, ref.name, refNS),
 						})
 					}
 				}
@@ -547,37 +548,22 @@ func collectStepReferences(step *ottoflowv1alpha1.Step) []stepRef {
 	return refs
 }
 
-// refLabel returns the field name to show in a validationError message for one reference kind.
-func refLabel(kind string) string {
-	switch kind {
-	case "Workflow":
-		return "workflowRef"
-	case "Agent":
-		return "agentRef"
-	case "StepTemplate":
-		return "stepTemplateRef"
-	case "MCPServer":
-		return "mcpToolCall.server"
-	default:
-		return kind
-	}
+// refKindInfo is how checkWorkflow reports and resolves one stepRef.kind: the field name to
+// show in a validationError message, and a constructor for the typed client.Object
+// k8sClient.Get should decode into.
+type refKindInfo struct {
+	label  string
+	newObj func() client.Object
 }
 
-// newRefObject returns a zero-value typed client.Object for kind, so k8sClient.Get can decode
-// into the correct CRD type. kind must be one collectStepReferences emits.
-func newRefObject(kind string) (client.Object, error) {
-	switch kind {
-	case "Workflow":
-		return &ottoflowv1alpha1.Workflow{}, nil
-	case "Agent":
-		return &ottoflowv1alpha1.Agent{}, nil
-	case "StepTemplate":
-		return &ottoflowv1alpha1.StepTemplate{}, nil
-	case "MCPServer":
-		return &ottoflowv1alpha1.MCPServer{}, nil
-	default:
-		return nil, fmt.Errorf("internal error: unknown reference kind %q", kind)
-	}
+// refKinds maps every kind collectStepReferences can emit to its refKindInfo. Keeping the
+// label and the object constructor in one table (instead of two parallel switches) means a new
+// reference kind can't have one added without the other.
+var refKinds = map[string]refKindInfo{
+	"Workflow":     {label: "workflowRef", newObj: func() client.Object { return &ottoflowv1alpha1.Workflow{} }},
+	"Agent":        {label: "agentRef", newObj: func() client.Object { return &ottoflowv1alpha1.Agent{} }},
+	"StepTemplate": {label: "stepTemplateRef", newObj: func() client.Object { return &ottoflowv1alpha1.StepTemplate{} }},
+	"MCPServer":    {label: "mcpToolCall.server", newObj: func() client.Object { return &ottoflowv1alpha1.MCPServer{} }},
 }
 
 // collectCELExpressions returns only the fields of a step that are definitively CEL

--- a/cli/cmd/validate_test.go
+++ b/cli/cmd/validate_test.go
@@ -158,9 +158,13 @@ func TestValidateStepRefs(t *testing.T) {
 		name        string
 		missingYAML string
 		presentYAML string
+		// wantMsgContains, when set, is asserted against the "missing is flagged" subtest's
+		// REF_NOT_FOUND message in addition to the shared code/count checks every case gets.
+		wantMsgContains []string
 	}{
 		{
-			name: "forEach stepTemplateRef",
+			name:            "forEach stepTemplateRef",
+			wantMsgContains: []string{"missing-tpl", "default"},
 			missingYAML: `apiVersion: ottoflow.nirmata.io/v1alpha1
 kind: Workflow
 metadata:
@@ -303,6 +307,11 @@ spec:
 				if len(errs) != 1 || errs[0].code != "REF_NOT_FOUND" {
 					t.Fatalf("expected exactly one REF_NOT_FOUND, got: %+v", errs)
 				}
+				for _, want := range tc.wantMsgContains {
+					if !strings.Contains(errs[0].message, want) {
+						t.Errorf("expected error message to contain %q, got: %s", want, errs[0].message)
+					}
+				}
 			})
 
 			t.Run("present is clean", func(t *testing.T) {
@@ -318,23 +327,6 @@ spec:
 			})
 		})
 	}
-
-	// The forEach case's missing-ref message additionally names the template and namespace,
-	// verified separately since the table above only checks the shared REF_NOT_FOUND shape.
-	t.Run("forEach stepTemplateRef message names template and namespace", func(t *testing.T) {
-		exec := buildLocalExecOrFatal(t, cases[0].missingYAML)
-		wf, err := exec.GetWorkflow(ctx, "wf", "default")
-		if err != nil {
-			t.Fatalf("GetWorkflow: %v", err)
-		}
-		errs := checkWorkflow(ctx, wf, exec.ControlClient(), celEnv, celEnvErr)
-		if len(errs) != 1 {
-			t.Fatalf("expected exactly one error, got: %+v", errs)
-		}
-		if !strings.Contains(errs[0].message, "missing-tpl") || !strings.Contains(errs[0].message, "default") {
-			t.Errorf("expected error naming template and namespace, got: %s", errs[0].message)
-		}
-	})
 }
 
 func TestValidateWorkflowRunRefs_MissingAndPresent(t *testing.T) {

--- a/cli/cmd/validate_test.go
+++ b/cli/cmd/validate_test.go
@@ -8,10 +8,12 @@ that can be found in the LICENSE.md file.
 package cmd
 
 import (
+	"context"
 	"strings"
 	"testing"
 
 	ottoflowv1alpha1 "github.com/nirmata/ottoflow/api/v1alpha1"
+	cliexec "github.com/nirmata/ottoflow/cli/internal/executor"
 	"github.com/nirmata/ottoflow/internal/webhook"
 	"github.com/nirmata/ottoflow/internal/workflow/executor"
 )
@@ -130,5 +132,310 @@ func TestCostAnalyzerCELExpressions(t *testing.T) {
 			t.Errorf("step %q: expr compile error: %s\n  expr: %s",
 				step.Name, iss.Err(), expr)
 		}
+	}
+}
+
+// buildLocalExecOrFatal builds a LocalWorkflowExecutor from an in-memory YAML manifest stream,
+// the same way local --workflow-dir validation does, without touching disk.
+func buildLocalExecOrFatal(t *testing.T, yamlDoc string) *cliexec.LocalWorkflowExecutor {
+	t.Helper()
+	exec := cliexec.NewLocalWorkflowExecutor(nil, "", 0, "", "")
+	if err := exec.LoadFromReader(strings.NewReader(yamlDoc)); err != nil {
+		t.Fatalf("LoadFromReader: %v", err)
+	}
+	return exec
+}
+
+// TestValidateStepRefs covers all four reference kinds Check 6 resolves: the direct
+// stepTemplateRef step type, forEach.stepTemplateRef, agentRef, and mcpToolCall.server. Each
+// case supplies a workflow-only manifest (the reference is missing) and a workflow+referent
+// manifest (the reference resolves), asserting REF_NOT_FOUND vs. clean respectively.
+func TestValidateStepRefs(t *testing.T) {
+	ctx := context.Background()
+	celEnv, celEnvErr := executor.NewValidationCELEnv()
+
+	cases := []struct {
+		name        string
+		missingYAML string
+		presentYAML string
+	}{
+		{
+			name: "forEach stepTemplateRef",
+			missingYAML: `apiVersion: ottoflow.nirmata.io/v1alpha1
+kind: Workflow
+metadata:
+  name: wf
+spec:
+  steps:
+    - name: loop
+      forEach:
+        items: '[]'
+        stepTemplateRef:
+          name: missing-tpl
+`,
+			presentYAML: `apiVersion: ottoflow.nirmata.io/v1alpha1
+kind: Workflow
+metadata:
+  name: wf
+spec:
+  steps:
+    - name: loop
+      forEach:
+        items: '[]'
+        stepTemplateRef:
+          name: present-tpl
+---
+apiVersion: ottoflow.nirmata.io/v1alpha1
+kind: StepTemplate
+metadata:
+  name: present-tpl
+spec:
+  step: {}
+`,
+		},
+		{
+			name: "direct stepTemplateRef",
+			missingYAML: `apiVersion: ottoflow.nirmata.io/v1alpha1
+kind: Workflow
+metadata:
+  name: wf
+spec:
+  steps:
+    - name: instantiate
+      stepTemplateRef:
+        name: missing-tpl
+`,
+			presentYAML: `apiVersion: ottoflow.nirmata.io/v1alpha1
+kind: Workflow
+metadata:
+  name: wf
+spec:
+  steps:
+    - name: instantiate
+      stepTemplateRef:
+        name: present-tpl
+---
+apiVersion: ottoflow.nirmata.io/v1alpha1
+kind: StepTemplate
+metadata:
+  name: present-tpl
+spec:
+  step: {}
+`,
+		},
+		{
+			name: "agentRef",
+			missingYAML: `apiVersion: ottoflow.nirmata.io/v1alpha1
+kind: Workflow
+metadata:
+  name: wf
+spec:
+  steps:
+    - name: ask
+      agentRef:
+        name: missing-agent
+`,
+			presentYAML: `apiVersion: ottoflow.nirmata.io/v1alpha1
+kind: Workflow
+metadata:
+  name: wf
+spec:
+  steps:
+    - name: ask
+      agentRef:
+        name: present-agent
+---
+apiVersion: ottoflow.nirmata.io/v1alpha1
+kind: Agent
+metadata:
+  name: present-agent
+spec:
+  prompt: "answer questions"
+  modelProvider: anthropic
+  modelName: claude-3-opus
+`,
+		},
+		{
+			name: "mcpToolCall.server",
+			missingYAML: `apiVersion: ottoflow.nirmata.io/v1alpha1
+kind: Workflow
+metadata:
+  name: wf
+spec:
+  steps:
+    - name: callTool
+      mcpToolCall:
+        server: missing-server
+        tool: some-tool
+`,
+			presentYAML: `apiVersion: ottoflow.nirmata.io/v1alpha1
+kind: Workflow
+metadata:
+  name: wf
+spec:
+  steps:
+    - name: callTool
+      mcpToolCall:
+        server: present-server
+        tool: some-tool
+---
+apiVersion: ottoflow.nirmata.io/v1alpha1
+kind: MCPServer
+metadata:
+  name: present-server
+spec:
+  transport:
+    type: stdio
+    command: ["echo"]
+`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Run("missing is flagged", func(t *testing.T) {
+				exec := buildLocalExecOrFatal(t, tc.missingYAML)
+				wf, err := exec.GetWorkflow(ctx, "wf", "default")
+				if err != nil {
+					t.Fatalf("GetWorkflow: %v", err)
+				}
+				errs := checkWorkflow(ctx, wf, exec.ControlClient(), celEnv, celEnvErr)
+				if len(errs) != 1 || errs[0].code != "REF_NOT_FOUND" {
+					t.Fatalf("expected exactly one REF_NOT_FOUND, got: %+v", errs)
+				}
+			})
+
+			t.Run("present is clean", func(t *testing.T) {
+				exec := buildLocalExecOrFatal(t, tc.presentYAML)
+				wf, err := exec.GetWorkflow(ctx, "wf", "default")
+				if err != nil {
+					t.Fatalf("GetWorkflow: %v", err)
+				}
+				errs := checkWorkflow(ctx, wf, exec.ControlClient(), celEnv, celEnvErr)
+				if len(errs) != 0 {
+					t.Errorf("expected no errors, got: %+v", errs)
+				}
+			})
+		})
+	}
+
+	// The forEach case's missing-ref message additionally names the template and namespace,
+	// verified separately since the table above only checks the shared REF_NOT_FOUND shape.
+	t.Run("forEach stepTemplateRef message names template and namespace", func(t *testing.T) {
+		exec := buildLocalExecOrFatal(t, cases[0].missingYAML)
+		wf, err := exec.GetWorkflow(ctx, "wf", "default")
+		if err != nil {
+			t.Fatalf("GetWorkflow: %v", err)
+		}
+		errs := checkWorkflow(ctx, wf, exec.ControlClient(), celEnv, celEnvErr)
+		if len(errs) != 1 {
+			t.Fatalf("expected exactly one error, got: %+v", errs)
+		}
+		if !strings.Contains(errs[0].message, "missing-tpl") || !strings.Contains(errs[0].message, "default") {
+			t.Errorf("expected error naming template and namespace, got: %s", errs[0].message)
+		}
+	})
+}
+
+func TestValidateWorkflowRunRefs_MissingAndPresent(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("missing workflow is flagged", func(t *testing.T) {
+		exec := buildLocalExecOrFatal(t, `apiVersion: ottoflow.nirmata.io/v1alpha1
+kind: WorkflowRun
+metadata:
+  name: my-run
+  namespace: default
+spec:
+  workflowRef:
+    name: missing-workflow
+    namespace: default
+`)
+		results := checkWorkflowRunRefs(ctx, exec)
+		if len(results) != 1 {
+			t.Fatalf("expected 1 failing WorkflowRun, got %d: %+v", len(results), results)
+		}
+		if results[0].runName != "my-run" {
+			t.Errorf("expected runName %q, got %q", "my-run", results[0].runName)
+		}
+		if len(results[0].errs) != 1 || !strings.Contains(results[0].errs[0].message, "missing-workflow") {
+			t.Errorf("expected REF_NOT_FOUND naming missing-workflow, got: %+v", results[0].errs)
+		}
+	})
+
+	t.Run("matching workflow is clean", func(t *testing.T) {
+		exec := buildLocalExecOrFatal(t, `apiVersion: ottoflow.nirmata.io/v1alpha1
+kind: Workflow
+metadata:
+  name: my-workflow
+  namespace: default
+spec:
+  steps:
+    - name: step1
+      expressions:
+        - name: a
+          expression: "'ok'"
+---
+apiVersion: ottoflow.nirmata.io/v1alpha1
+kind: WorkflowRun
+metadata:
+  name: my-run
+  namespace: default
+spec:
+  workflowRef:
+    name: my-workflow
+    namespace: default
+`)
+		results := checkWorkflowRunRefs(ctx, exec)
+		if len(results) != 0 {
+			t.Errorf("expected no failing WorkflowRuns, got: %+v", results)
+		}
+	})
+}
+
+// TestValidateWorkflowRunRefs_ResolvesNamespaceFromLoader is a regression test: a WorkflowRun
+// declaring no namespace anywhere gets its Namespace field force-defaulted to "default" by
+// indexWorkflowRuns, but the loader separately rebinds it (for lookup purposes) into the
+// namespace of the single Workflow matching its workflowRef.name. checkWorkflowRunRefs must
+// use that rebound ResolvedNamespace, not Run.Namespace, or it reports a false REF_NOT_FOUND
+// against a WorkflowRun that is actually fine.
+func TestValidateWorkflowRunRefs_ResolvesNamespaceFromLoader(t *testing.T) {
+	ctx := context.Background()
+	exec := buildLocalExecOrFatal(t, `apiVersion: ottoflow.nirmata.io/v1alpha1
+kind: Workflow
+metadata:
+  name: my-workflow
+  namespace: ottoflow
+spec:
+  steps:
+    - name: step1
+      expressions:
+        - name: a
+          expression: "'ok'"
+---
+apiVersion: ottoflow.nirmata.io/v1alpha1
+kind: WorkflowRun
+metadata:
+  name: my-run
+spec:
+  workflowRef:
+    name: my-workflow
+`)
+
+	lrs := exec.ListWorkflowRuns()
+	if len(lrs) != 1 {
+		t.Fatalf("expected 1 loaded WorkflowRun, got %d", len(lrs))
+	}
+	if lrs[0].Run.Namespace != "default" {
+		t.Fatalf("test assumption invalid: expected Run.Namespace force-defaulted to %q, got %q",
+			"default", lrs[0].Run.Namespace)
+	}
+	if lrs[0].ResolvedNamespace != "ottoflow" {
+		t.Fatalf("expected ResolvedNamespace %q, got %q", "ottoflow", lrs[0].ResolvedNamespace)
+	}
+
+	results := checkWorkflowRunRefs(ctx, exec)
+	if len(results) != 0 {
+		t.Errorf("expected clean (no false positive from using Run.Namespace=default), got: %+v", results)
 	}
 }

--- a/cli/cmd/validate_test.go
+++ b/cli/cmd/validate_test.go
@@ -9,6 +9,8 @@ package cmd
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -146,10 +148,11 @@ func buildLocalExecOrFatal(t *testing.T, yamlDoc string) *cliexec.LocalWorkflowE
 	return exec
 }
 
-// TestValidateStepRefs covers all four reference kinds Check 6 resolves: the direct
-// stepTemplateRef step type, forEach.stepTemplateRef, agentRef, and mcpToolCall.server. Each
-// case supplies a workflow-only manifest (the reference is missing) and a workflow+referent
-// manifest (the reference resolves), asserting REF_NOT_FOUND vs. clean respectively.
+// TestValidateStepRefs covers every reference kind Check 6 resolves: the direct
+// stepTemplateRef step type, forEach.stepTemplateRef, agentRef, mcpToolCall.server, a bare
+// step.workflowRef, and forEach.step's own inline agentRef. Each case supplies a
+// workflow-only manifest (the reference is missing) and a workflow+referent manifest (the
+// reference resolves), asserting REF_NOT_FOUND vs. clean respectively.
 func TestValidateStepRefs(t *testing.T) {
 	ctx := context.Background()
 	celEnv, celEnvErr := executor.NewValidationCELEnv()
@@ -282,6 +285,121 @@ spec:
       mcpToolCall:
         server: present-server
         tool: some-tool
+---
+apiVersion: ottoflow.nirmata.io/v1alpha1
+kind: MCPServer
+metadata:
+  name: present-server
+spec:
+  transport:
+    type: stdio
+    command: ["echo"]
+`,
+		},
+		{
+			// Bare step.workflowRef (sub-workflow execution), distinct from forEach.step's
+			// inline workflowRef covered below.
+			name:            "workflowRef",
+			wantMsgContains: []string{"missing-workflow", "default"},
+			missingYAML: `apiVersion: ottoflow.nirmata.io/v1alpha1
+kind: Workflow
+metadata:
+  name: wf
+spec:
+  steps:
+    - name: sub
+      workflowRef:
+        name: missing-workflow
+`,
+			presentYAML: `apiVersion: ottoflow.nirmata.io/v1alpha1
+kind: Workflow
+metadata:
+  name: wf
+spec:
+  steps:
+    - name: sub
+      workflowRef:
+        name: present-workflow
+---
+apiVersion: ottoflow.nirmata.io/v1alpha1
+kind: Workflow
+metadata:
+  name: present-workflow
+spec: {}
+`,
+		},
+		{
+			// forEach.step's own inline agentRef -- previously not statically checked at
+			// all (collectStepReferences skipped everything inside an inline forEach.step).
+			name:            "forEach.step agentRef",
+			wantMsgContains: []string{"missing-agent", "default"},
+			missingYAML: `apiVersion: ottoflow.nirmata.io/v1alpha1
+kind: Workflow
+metadata:
+  name: wf
+spec:
+  steps:
+    - name: loop
+      forEach:
+        items: '[]'
+        step:
+          agentRef:
+            name: missing-agent
+`,
+			presentYAML: `apiVersion: ottoflow.nirmata.io/v1alpha1
+kind: Workflow
+metadata:
+  name: wf
+spec:
+  steps:
+    - name: loop
+      forEach:
+        items: '[]'
+        step:
+          agentRef:
+            name: present-agent
+---
+apiVersion: ottoflow.nirmata.io/v1alpha1
+kind: Agent
+metadata:
+  name: present-agent
+spec:
+  prompt: "answer questions"
+  modelProvider: anthropic
+  modelName: claude-3-opus
+`,
+		},
+		{
+			// forEach.step's own inline mcpToolCall.server.
+			name:            "forEach.step mcpToolCall.server",
+			wantMsgContains: []string{"missing-server", "default"},
+			missingYAML: `apiVersion: ottoflow.nirmata.io/v1alpha1
+kind: Workflow
+metadata:
+  name: wf
+spec:
+  steps:
+    - name: loop
+      forEach:
+        items: '[]'
+        step:
+          mcpToolCall:
+            server: missing-server
+            tool: some-tool
+`,
+			presentYAML: `apiVersion: ottoflow.nirmata.io/v1alpha1
+kind: Workflow
+metadata:
+  name: wf
+spec:
+  steps:
+    - name: loop
+      forEach:
+        items: '[]'
+        step:
+          mcpToolCall:
+            server: present-server
+            tool: some-tool
 ---
 apiVersion: ottoflow.nirmata.io/v1alpha1
 kind: MCPServer
@@ -429,5 +547,157 @@ spec:
 	results := checkWorkflowRunRefs(ctx, exec)
 	if len(results) != 0 {
 		t.Errorf("expected clean (no false positive from using Run.Namespace=default), got: %+v", results)
+	}
+}
+
+// TestValidateStepRefs_StepTemplateInnerRef verifies checkStepRefs checks one level into a
+// resolved stepTemplateRef: the workflow's own reference to the template resolves fine, but
+// the template's own step (its Spec.Step) references a missing Agent. Without this check, a
+// shared template with a stale internal ref would only fail at run time.
+func TestValidateStepRefs_StepTemplateInnerRef(t *testing.T) {
+	ctx := context.Background()
+	celEnv, celEnvErr := executor.NewValidationCELEnv()
+
+	t.Run("missing inner ref is flagged", func(t *testing.T) {
+		exec := buildLocalExecOrFatal(t, `apiVersion: ottoflow.nirmata.io/v1alpha1
+kind: Workflow
+metadata:
+  name: wf
+spec:
+  steps:
+    - name: instantiate
+      stepTemplateRef:
+        name: shared-tpl
+---
+apiVersion: ottoflow.nirmata.io/v1alpha1
+kind: StepTemplate
+metadata:
+  name: shared-tpl
+spec:
+  step:
+    agentRef:
+      name: missing-agent
+`)
+		wf, err := exec.GetWorkflow(ctx, "wf", "default")
+		if err != nil {
+			t.Fatalf("GetWorkflow: %v", err)
+		}
+		errs := checkWorkflow(ctx, wf, exec.ControlClient(), celEnv, celEnvErr)
+		if len(errs) != 1 || errs[0].code != "REF_NOT_FOUND" {
+			t.Fatalf("expected exactly one REF_NOT_FOUND, got: %+v", errs)
+		}
+		if !strings.Contains(errs[0].message, "missing-agent") || !strings.Contains(errs[0].message, "shared-tpl") {
+			t.Errorf("expected error naming both the missing agent and the template it came from, got: %s", errs[0].message)
+		}
+	})
+
+	t.Run("present inner ref is clean", func(t *testing.T) {
+		exec := buildLocalExecOrFatal(t, `apiVersion: ottoflow.nirmata.io/v1alpha1
+kind: Workflow
+metadata:
+  name: wf
+spec:
+  steps:
+    - name: instantiate
+      stepTemplateRef:
+        name: shared-tpl
+---
+apiVersion: ottoflow.nirmata.io/v1alpha1
+kind: StepTemplate
+metadata:
+  name: shared-tpl
+spec:
+  step:
+    agentRef:
+      name: present-agent
+---
+apiVersion: ottoflow.nirmata.io/v1alpha1
+kind: Agent
+metadata:
+  name: present-agent
+spec:
+  prompt: "answer questions"
+  modelProvider: anthropic
+  modelName: claude-3-opus
+`)
+		wf, err := exec.GetWorkflow(ctx, "wf", "default")
+		if err != nil {
+			t.Fatalf("GetWorkflow: %v", err)
+		}
+		errs := checkWorkflow(ctx, wf, exec.ControlClient(), celEnv, celEnvErr)
+		if len(errs) != 0 {
+			t.Errorf("expected no errors, got: %+v", errs)
+		}
+	})
+}
+
+// writeValidateTestFile writes content to a temp file and returns its path, for fileRefWarnings
+// tests below which -- unlike buildLocalExecOrFatal -- need a real file on disk to exercise
+// loadWorkflowFromFile and fileRefWarnings' independent os.ReadFile.
+func writeValidateTestFile(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "wf.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write test file: %v", err)
+	}
+	return path
+}
+
+// TestFileRefWarnings_SelfContainedIsClean covers the "-f with a self-contained file" half of
+// finding #4: a file holding the Workflow plus its own StepTemplate has nothing to warn about.
+func TestFileRefWarnings_SelfContainedIsClean(t *testing.T) {
+	ctx := context.Background()
+	path := writeValidateTestFile(t, `apiVersion: ottoflow.nirmata.io/v1alpha1
+kind: Workflow
+metadata:
+  name: wf
+spec:
+  steps:
+    - name: instantiate
+      stepTemplateRef:
+        name: present-tpl
+---
+apiVersion: ottoflow.nirmata.io/v1alpha1
+kind: StepTemplate
+metadata:
+  name: present-tpl
+spec:
+  step: {}
+`)
+	wf, err := loadWorkflowFromFile(path)
+	if err != nil {
+		t.Fatalf("loadWorkflowFromFile: %v", err)
+	}
+	if warnings := fileRefWarnings(ctx, path, wf); len(warnings) != 0 {
+		t.Errorf("expected no warnings for a self-contained file, got: %+v", warnings)
+	}
+}
+
+// TestFileRefWarnings_MissingRefIsWarningNotError covers the "-f with a workflow referencing
+// a missing object -> warning surfaced (non-fatal)" half of finding #4: fileRefWarnings
+// reports the unresolved ref, but loadWorkflowFromFile -- the call that determines whether
+// `validate -f` fails -- succeeds regardless, so the ref check never becomes fatal in -f mode.
+func TestFileRefWarnings_MissingRefIsWarningNotError(t *testing.T) {
+	ctx := context.Background()
+	path := writeValidateTestFile(t, `apiVersion: ottoflow.nirmata.io/v1alpha1
+kind: Workflow
+metadata:
+  name: wf
+spec:
+  steps:
+    - name: ask
+      agentRef:
+        name: missing-agent
+`)
+	wf, err := loadWorkflowFromFile(path)
+	if err != nil {
+		t.Fatalf("loadWorkflowFromFile: %v (must succeed -- the ref check is a warning, not a load failure)", err)
+	}
+	warnings := fileRefWarnings(ctx, path, wf)
+	if len(warnings) != 1 || warnings[0].code != "REF_NOT_FOUND" {
+		t.Fatalf("expected exactly one REF_NOT_FOUND warning, got: %+v", warnings)
+	}
+	if !strings.Contains(warnings[0].message, "missing-agent") {
+		t.Errorf("expected warning naming missing-agent, got: %s", warnings[0].message)
 	}
 }

--- a/cli/internal/executor/local_executor.go
+++ b/cli/internal/executor/local_executor.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sort"
 	"strings"
 	"time"
 
@@ -337,13 +338,26 @@ type LoadedWorkflowRun struct {
 }
 
 // ListWorkflowRuns returns every loaded WorkflowRun paired with the namespace the loader
-// resolved it into.
+// resolved it into, sorted by (ResolvedNamespace, Run.Name) so callers that print one line
+// per run (e.g. `validate --workflow-dir`'s FAIL workflowRun output) get stable, reproducible
+// ordering instead of Go's randomized map iteration order.
 func (e *LocalWorkflowExecutor) ListWorkflowRuns() []LoadedWorkflowRun {
 	out := make([]LoadedWorkflowRun, 0, len(e.workflowRuns))
 	for key, wr := range e.workflowRuns {
+		// ResolvedNamespace is recovered from the index key ("namespace/workflowRef.name")
+		// rather than carried as its own field on LoadedWorkflowRun/indexWorkflowRuns: the
+		// index map is also read directly by mergeInputValues and workflowRunNameMismatch,
+		// and threading an explicit namespace field through those call sites for this one
+		// caller wasn't worth the churn.
 		resolvedNS := strings.TrimSuffix(key, "/"+wr.Spec.WorkflowRef.Name)
 		out = append(out, LoadedWorkflowRun{ResolvedNamespace: resolvedNS, Run: wr})
 	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].ResolvedNamespace != out[j].ResolvedNamespace {
+			return out[i].ResolvedNamespace < out[j].ResolvedNamespace
+		}
+		return out[i].Run.Name < out[j].Run.Name
+	})
 	return out
 }
 

--- a/cli/internal/executor/local_executor.go
+++ b/cli/internal/executor/local_executor.go
@@ -317,6 +317,36 @@ func objectKey(obj client.Object) string {
 	return fmt.Sprintf("%s/%s/%s", reflect.TypeOf(obj).String(), ns, obj.GetName())
 }
 
+// ControlClient returns the fake control-plane client the loader populated from the loaded
+// manifests, so callers outside this package (e.g. `ottoflow validate`) can run the same
+// reference-existence checks the local executor itself relies on.
+func (e *LocalWorkflowExecutor) ControlClient() client.Client {
+	return e.controlClient
+}
+
+// LoadedWorkflowRun pairs a loaded WorkflowRun with the namespace the loader
+// resolved it into (recovered from the index key), which is the namespace the
+// runtime uses to find its Workflow. This can differ from Run.Namespace, which
+// indexWorkflowRuns force-defaults to "default".
+// NOTE: the index map keys by resolvedNs + "/" + workflowRef.Name, so two runs
+// referencing the same Workflow in one namespace collide last-wins -- this list
+// therefore under-reports such duplicates (a benign under-check, never a false positive).
+type LoadedWorkflowRun struct {
+	ResolvedNamespace string
+	Run               *ottoflowv1alpha1.WorkflowRun
+}
+
+// ListWorkflowRuns returns every loaded WorkflowRun paired with the namespace the loader
+// resolved it into.
+func (e *LocalWorkflowExecutor) ListWorkflowRuns() []LoadedWorkflowRun {
+	out := make([]LoadedWorkflowRun, 0, len(e.workflowRuns))
+	for key, wr := range e.workflowRuns {
+		resolvedNS := strings.TrimSuffix(key, "/"+wr.Spec.WorkflowRef.Name)
+		out = append(out, LoadedWorkflowRun{ResolvedNamespace: resolvedNS, Run: wr})
+	}
+	return out
+}
+
 // GetWorkflow returns a Workflow by name and namespace from the loaded manifests.
 func (e *LocalWorkflowExecutor) GetWorkflow(ctx context.Context, name, namespace string) (*ottoflowv1alpha1.Workflow, error) {
 	if e.controlClient == nil {

--- a/cli/internal/executor/local_executor_test.go
+++ b/cli/internal/executor/local_executor_test.go
@@ -479,3 +479,71 @@ spec:
 		t.Errorf("with client: expected a not-found error naming the pod, got: %v", err)
 	}
 }
+
+// TestListWorkflowRuns_SortedDeterministically is a regression test: ListWorkflowRuns used to
+// iterate e.workflowRuns (a Go map) directly, so the order of e.g. `validate --workflow-dir`'s
+// "FAIL workflowRun ..." lines was nondeterministic across runs. It must return entries sorted
+// by (ResolvedNamespace, Run.Name) regardless of map iteration order.
+func TestListWorkflowRuns_SortedDeterministically(t *testing.T) {
+	dir := t.TempDir()
+
+	// Three WorkflowRuns whose index keys ("namespace/workflowRef.name") are all distinct, so
+	// no two collide and all three are retained. Metadata.name intentionally out of order.
+	yaml := `apiVersion: ottoflow.nirmata.io/v1alpha1
+kind: WorkflowRun
+metadata:
+  name: run-z
+spec:
+  workflowRef:
+    name: wf-z
+    namespace: zeta
+---
+apiVersion: ottoflow.nirmata.io/v1alpha1
+kind: WorkflowRun
+metadata:
+  name: run-b
+spec:
+  workflowRef:
+    name: wf-b
+    namespace: alpha
+---
+apiVersion: ottoflow.nirmata.io/v1alpha1
+kind: WorkflowRun
+metadata:
+  name: run-a
+spec:
+  workflowRef:
+    name: wf-a
+    namespace: alpha
+`
+	if err := os.WriteFile(filepath.Join(dir, "runs.yaml"), []byte(yaml), 0600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	exec := NewLocalWorkflowExecutor(nil, "", 5, "", "")
+	if err := exec.LoadFromDirectory(dir); err != nil {
+		t.Fatalf("LoadFromDirectory: %v", err)
+	}
+
+	// Run the listing several times: a map-iteration-order bug wouldn't necessarily surface
+	// on the first call.
+	for i := 0; i < 5; i++ {
+		lrs := exec.ListWorkflowRuns()
+		if len(lrs) != 3 {
+			t.Fatalf("expected 3 WorkflowRuns, got %d", len(lrs))
+		}
+		wantOrder := []struct {
+			ns, name string
+		}{
+			{"alpha", "run-a"},
+			{"alpha", "run-b"},
+			{"zeta", "run-z"},
+		}
+		for i, want := range wantOrder {
+			if lrs[i].ResolvedNamespace != want.ns || lrs[i].Run.Name != want.name {
+				t.Fatalf("entry %d: expected (%s, %s), got (%s, %s)",
+					i, want.ns, want.name, lrs[i].ResolvedNamespace, lrs[i].Run.Name)
+			}
+		}
+	}
+}

--- a/docs/cli/ottoflow_validate.md
+++ b/docs/cli/ottoflow_validate.md
@@ -11,7 +11,15 @@ Checks performed:
   - Step expression-to-dependsOn alignment (MISSING_DEPENDS_ON)
   - Undefined inputs.* references (UNDEFINED_INPUT)
   - CEL expression syntax (compile-time, no evaluation)
-  - WorkflowRef and AgentRef existence (when connected to a cluster)
+  - workflowRef, agentRef, stepTemplateRef (direct and forEach, plus one level into a
+    resolved template's own step), mcpToolCall.server, and the workflowRef/agentRef/
+    mcpToolCall.server declared inline on a forEach.step -- checked against the cluster in
+    cluster mode, or against the manifests loaded from --workflow-dir in local mode; also
+    checked for a loaded WorkflowRun's workflowRef.
+    In -f/--file mode, these are checked against every OttoFlow object found in the same
+    file (e.g. a Workflow plus its own StepTemplate/Agent/MCPServer), but an unresolved ref
+    is reported as a WARNING rather than a failure: a single file may legitimately reference
+    objects that are applied to the cluster separately and are not visible to this command.
 
 Examples:
   ottoflow validate --workflow-dir samples        # validate all workflows in directory

--- a/docs/user/concepts/concepts-guide.md
+++ b/docs/user/concepts/concepts-guide.md
@@ -306,7 +306,7 @@ ottoflow run <workflow-name> --workflow-dir ./workflows
 In local mode:
 - Workflow YAML is loaded from disk into a fake control-plane client built from the files in that directory — StepTemplates (and other referenced OttoFlow objects) must live under the same directory tree
 - `WorkflowExecutor` runs in-process (no Job is created)
-- `--namespace` must match the workflow's own `metadata.namespace`, even in local mode
+- `--namespace` is only used to disambiguate when multiple loaded workflows share the same name; a uniquely-named workflow resolves regardless of `--namespace`
 - Agent steps use a local `agentExecutor` (requires LLM credentials)
 - MCP servers still connect via stdio/http
 - `resourceMetrics()` works: a metrics client is wired from your kubeconfig

--- a/docs/user/reference/configuration.md
+++ b/docs/user/reference/configuration.md
@@ -28,7 +28,7 @@ Each section below applies to a specific component. See [Architecture](../concep
 
 | Flag | Shorthand | Default | Description |
 |------|-----------|---------|-------------|
-| `--namespace` | `-n` | kubeconfig context namespace, else `ottoflow` | Kubernetes namespace for workflow resources. In local mode (`--workflow-dir`) this must match the workflow's own `metadata.namespace`. |
+| `--namespace` | `-n` | kubeconfig context namespace, else `ottoflow` | Kubernetes namespace for workflow resources. In local mode (`--workflow-dir`), `--namespace` is only used to disambiguate when multiple loaded workflows share the same name; a uniquely-named workflow resolves regardless of `--namespace`. |
 | `--kubeconfig` | | `$HOME/.kube/config` (honors `$KUBECONFIG`) | Path to kubeconfig file |
 
 ### `ottoflow run`

--- a/docs/user/tasks/README.md
+++ b/docs/user/tasks/README.md
@@ -18,4 +18,4 @@ For step types (resource queries, agents, mutate, forEach, and more), see the [W
 
 - **[Concepts](../concepts/)** - Understanding OttoFlow architecture
 - **[Reference](../reference/)** - API and CEL function reference
-- **[Examples](../../../samples/workflows/)** - 30+ sample workflows
+- **[Examples](../../../samples/workflows/)** - 80+ sample workflows

--- a/internal/workflow/executor/foreach_executor.go
+++ b/internal/workflow/executor/foreach_executor.go
@@ -133,19 +133,12 @@ func (e *WorkflowExecutor) executeForEach(ctx context.Context, workflowRun *otto
 			len(results.Failed), results.Failed[0].Error)
 	}
 
-	// A forEach where every item failed (or none completed at all) must never report success,
-	// regardless of itemFailurePolicy -- Continue only tolerates partial failure, not total failure.
-	// itemsList is non-empty here: the len(itemsList) == 0 case already returned above.
-	succeeded := len(results.Results) - len(results.Failed)
-	if succeeded == 0 {
-		if len(results.Failed) > 0 {
-			return fmt.Errorf("forEach: all %d item(s) failed with itemFailurePolicy=%s; first failure to complete: %s",
-				len(itemsList), itemFailurePolicy, results.Failed[0].Error)
-		}
-		return fmt.Errorf("forEach: no items completed successfully (loop cancelled or incomplete); %d item(s) requested", len(itemsList))
-	}
-
-	// Evaluate step-level outputs (if any) that can reference results
+	// Evaluate step-level outputs (if any) that can reference results. This must happen
+	// before the succeeded==0 guard below returns an error: a forEach step can carry its
+	// own step-level failurePolicy: Continue, which lets the workflow proceed past a Failed
+	// forEach step -- but only if the step's declared outputs actually got written to
+	// context. Otherwise a downstream steps.<name>.<out> / variables.<out> read would hit
+	// "no such key" even though the workflow "succeeded".
 	if len(step.Outputs) > 0 {
 		// Read updated context (now includes steps map with results)
 		contextData, err := e.contextManager.ReadContext(ctx)
@@ -169,12 +162,25 @@ func (e *WorkflowExecutor) executeForEach(ctx context.Context, workflowRun *otto
 		}
 	}
 
+	// A forEach where every item failed (or none completed at all) must never report success,
+	// regardless of itemFailurePolicy -- Continue only tolerates partial failure, not total failure.
+	// itemsList is non-empty here: the len(itemsList) == 0 case already returned above.
+	succeeded := len(results.Results) - len(results.Failed)
+	if succeeded == 0 {
+		if len(results.Failed) > 0 {
+			return fmt.Errorf("forEach: all %d item(s) failed with itemFailurePolicy=%s; first failure to complete: %s",
+				len(itemsList), itemFailurePolicy, results.Failed[0].Error)
+		}
+		return fmt.Errorf("forEach: no items completed successfully (loop cancelled or incomplete); %d item(s) requested", len(itemsList))
+	}
+
 	// itemFailurePolicy=Continue succeeds by design, but a partially or fully failed loop
-	// must not look identical to a clean one. Record the tally on the step message.
+	// must not look identical to a clean one. Record the tally on the step message. Reuses
+	// the same succeeded count as the guard above so the two never disagree.
 	if len(results.Failed) > 0 {
 		if st, ok := workflowRun.Status.StepStatuses[step.Name]; ok {
 			st.Message = fmt.Sprintf("%d/%d items succeeded, %d failed",
-				len(itemsList)-len(results.Failed), len(itemsList), len(results.Failed))
+				succeeded, len(itemsList), len(results.Failed))
 			workflowRun.Status.StepStatuses[step.Name] = st
 			e.invokeForEachProgressCallback(workflowRun)
 		}

--- a/internal/workflow/executor/foreach_executor.go
+++ b/internal/workflow/executor/foreach_executor.go
@@ -133,6 +133,17 @@ func (e *WorkflowExecutor) executeForEach(ctx context.Context, workflowRun *otto
 			len(results.Failed), results.Failed[0].Error)
 	}
 
+	// A forEach where every item failed (or none completed at all) must never report success,
+	// regardless of itemFailurePolicy -- Continue only tolerates partial failure, not total failure.
+	succeeded := len(results.Results) - len(results.Failed)
+	if len(itemsList) > 0 && succeeded == 0 {
+		if len(results.Failed) > 0 {
+			return fmt.Errorf("forEach: all %d item(s) failed with itemFailurePolicy=%s; first failure to complete: %s",
+				len(itemsList), itemFailurePolicy, results.Failed[0].Error)
+		}
+		return fmt.Errorf("forEach: no items completed successfully (loop cancelled or incomplete); %d item(s) requested", len(itemsList))
+	}
+
 	// Evaluate step-level outputs (if any) that can reference results
 	if len(step.Outputs) > 0 {
 		// Read updated context (now includes steps map with results)

--- a/internal/workflow/executor/foreach_executor.go
+++ b/internal/workflow/executor/foreach_executor.go
@@ -135,8 +135,9 @@ func (e *WorkflowExecutor) executeForEach(ctx context.Context, workflowRun *otto
 
 	// A forEach where every item failed (or none completed at all) must never report success,
 	// regardless of itemFailurePolicy -- Continue only tolerates partial failure, not total failure.
+	// itemsList is non-empty here: the len(itemsList) == 0 case already returned above.
 	succeeded := len(results.Results) - len(results.Failed)
-	if len(itemsList) > 0 && succeeded == 0 {
+	if succeeded == 0 {
 		if len(results.Failed) > 0 {
 			return fmt.Errorf("forEach: all %d item(s) failed with itemFailurePolicy=%s; first failure to complete: %s",
 				len(itemsList), itemFailurePolicy, results.Failed[0].Error)

--- a/internal/workflow/executor/foreach_executor.go
+++ b/internal/workflow/executor/foreach_executor.go
@@ -167,11 +167,11 @@ func (e *WorkflowExecutor) executeForEach(ctx context.Context, workflowRun *otto
 	// itemsList is non-empty here: the len(itemsList) == 0 case already returned above.
 	succeeded := len(results.Results) - len(results.Failed)
 	if succeeded == 0 {
+		firstFailure := ""
 		if len(results.Failed) > 0 {
-			return fmt.Errorf("forEach: all %d item(s) failed with itemFailurePolicy=%s; first failure to complete: %s",
-				len(itemsList), itemFailurePolicy, results.Failed[0].Error)
+			firstFailure = results.Failed[0].Error
 		}
-		return fmt.Errorf("forEach: no items completed successfully (loop cancelled or incomplete); %d item(s) requested", len(itemsList))
+		return foreachFailureError(len(itemsList), len(results.Failed), itemFailurePolicy, firstFailure)
 	}
 
 	// itemFailurePolicy=Continue succeeds by design, but a partially or fully failed loop
@@ -190,6 +190,26 @@ func (e *WorkflowExecutor) executeForEach(ctx context.Context, workflowRun *otto
 	}
 
 	return nil
+}
+
+// foreachFailureError builds the terminal error for a forEach loop that produced zero
+// successful items. failed is the number of items that recorded a failure; because a worker
+// records a failure entry and a result entry together, failed also equals the number of items
+// that ran to completion. When failed < requested, the remaining items never recorded a result
+// -- the context was cancelled mid-loop -- so they are reported as incomplete rather than folded
+// into an "all N failed" claim. firstFailure is the first failure message by completion order,
+// or "" when nothing failed (failed == 0).
+func foreachFailureError(requested, failed int, itemFailurePolicy, firstFailure string) error {
+	switch {
+	case failed == 0:
+		return fmt.Errorf("forEach: no items completed successfully (loop cancelled or incomplete); %d item(s) requested", requested)
+	case failed < requested:
+		return fmt.Errorf("forEach: %d of %d item(s) failed and %d did not complete (loop cancelled or incomplete) with itemFailurePolicy=%s; first failure to complete: %s",
+			failed, requested, requested-failed, itemFailurePolicy, firstFailure)
+	default:
+		return fmt.Errorf("forEach: all %d item(s) failed with itemFailurePolicy=%s; first failure to complete: %s",
+			requested, itemFailurePolicy, firstFailure)
+	}
 }
 
 // processItemsConcurrently processes items using a worker pool pattern

--- a/internal/workflow/executor/foreach_executor_test.go
+++ b/internal/workflow/executor/foreach_executor_test.go
@@ -676,6 +676,62 @@ var _ = Describe("ForEach Executor", func() {
 			Expect(failed).To(HaveLen(1))
 		})
 
+		It("still writes step outputs when every item fails under a step-level failurePolicy: Continue, so a downstream step can read them", func() {
+			// Distinct from itemFailurePolicy (which governs individual items within the
+			// forEach): step.FailurePolicy is the outer, step-level escape hatch that lets the
+			// *workflow* proceed past this step even though it ends up Failed. The forEach step
+			// declares its own output (a count of failed items) and a downstream step reads it.
+			workflow := &ottoflowv1alpha1.Workflow{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-workflow", Namespace: "default"},
+				Spec: ottoflowv1alpha1.WorkflowSpec{
+					Variables: []ottoflowv1alpha1.Variable{
+						{Name: "items", Expression: `["a", "b", "c"]`},
+					},
+					Steps: []ottoflowv1alpha1.Step{
+						{
+							Name: "loop",
+							ForEach: &ottoflowv1alpha1.StepForEach{
+								Items: `variables.items`,
+								Step: &ottoflowv1alpha1.StepForEachStep{
+									Expressions: []ottoflowv1alpha1.Expression{
+										{Name: "boom", Expression: `variables.item.noSuchField`},
+									},
+								},
+								MaxConcurrency:    1,
+								ItemFailurePolicy: ottoflowv1alpha1.FailurePolicyContinue,
+							},
+							Outputs: []ottoflowv1alpha1.Output{
+								{Name: "failedCount", Expression: `size(steps.loop.failed)`},
+							},
+							FailurePolicy: ottoflowv1alpha1.FailurePolicyContinue,
+						},
+						{
+							Name:      "afterLoop",
+							DependsOn: []string{"loop"},
+							Outputs: []ottoflowv1alpha1.Output{
+								// Step outputs land in the flat variables map (no per-step
+								// namespace -- see ContextManager.WriteStepOutputs), so this
+								// reads the forEach step's declared output as variables.failedCount.
+								{Name: "echoedFailedCount", Expression: `variables.failedCount`},
+							},
+						},
+					},
+				},
+			}
+			Expect(workflowExecutor.contextManager.InitializeContext(ctx, workflow, workflowRun.Spec.InputValues)).To(Succeed())
+
+			// step-level failurePolicy: Continue means ExecuteWorkflow itself must not error,
+			// even though the forEach step is Failed.
+			Expect(workflowExecutor.ExecuteWorkflow(ctx, workflow, workflowRun)).To(Succeed())
+
+			Expect(workflowRun.Status.StepStatuses["loop"].Phase).To(Equal(ottoflowv1alpha1.StepPhaseFailed))
+			Expect(workflowRun.Status.StepStatuses["afterLoop"].Phase).To(Equal(ottoflowv1alpha1.StepPhaseSucceeded))
+
+			variables := workflowExecutor.contextManager.GetContext()["variables"].(map[string]interface{})
+			Expect(variables["failedCount"]).To(Equal(int64(3)))
+			Expect(variables["echoedFailedCount"]).To(Equal(int64(3)))
+		})
+
 		It("fails the step when stepTemplateRef resolution fails for every item", func() {
 			// No StepTemplate named "does-not-exist" is registered with the fake client, so
 			// every item fails during template resolution before the child step ever runs.

--- a/internal/workflow/executor/foreach_executor_test.go
+++ b/internal/workflow/executor/foreach_executor_test.go
@@ -601,9 +601,10 @@ var _ = Describe("ForEach Executor", func() {
 	})
 
 	Context("When items fail", func() {
-		// alwaysFailingForEach builds a workflow whose every forEach item fails: the child
-		// expression indexes a field on a string item, which CEL rejects at evaluation.
-		alwaysFailingForEach := func(policy string) *ottoflowv1alpha1.Workflow {
+		// forEachWorkflow builds a workflow with a single forEach step over ["a", "b", "c"]:
+		// childExpr is evaluated once per item (as MaxConcurrency=1, so results stay
+		// deterministic regardless of completion order) under the given itemFailurePolicy.
+		forEachWorkflow := func(policy, childExpr string) *ottoflowv1alpha1.Workflow {
 			return &ottoflowv1alpha1.Workflow{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-workflow", Namespace: "default"},
 				Spec: ottoflowv1alpha1.WorkflowSpec{
@@ -617,7 +618,7 @@ var _ = Describe("ForEach Executor", func() {
 								Items: `variables.items`,
 								Step: &ottoflowv1alpha1.StepForEachStep{
 									Expressions: []ottoflowv1alpha1.Expression{
-										{Name: "boom", Expression: `variables.item.noSuchField`},
+										{Name: "boom", Expression: childExpr},
 									},
 								},
 								MaxConcurrency:    1,
@@ -627,6 +628,12 @@ var _ = Describe("ForEach Executor", func() {
 					},
 				},
 			}
+		}
+
+		// alwaysFailingForEach builds a workflow whose every forEach item fails: the child
+		// expression indexes a field on a string item, which CEL rejects at evaluation.
+		alwaysFailingForEach := func(policy string) *ottoflowv1alpha1.Workflow {
+			return forEachWorkflow(policy, `variables.item.noSuchField`)
 		}
 
 		It("fails the step when itemFailurePolicy is Fail", func() {
@@ -657,31 +664,8 @@ var _ = Describe("ForEach Executor", func() {
 		})
 
 		It("stays Succeeded with an accurate tally when only some items fail under itemFailurePolicy=Continue", func() {
-			// Only item "b" fails (field access on a string); "a" and "c" succeed. MaxConcurrency=1
-			// keeps this deterministic so the tally below is stable regardless of completion order.
-			workflow := &ottoflowv1alpha1.Workflow{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-workflow", Namespace: "default"},
-				Spec: ottoflowv1alpha1.WorkflowSpec{
-					Variables: []ottoflowv1alpha1.Variable{
-						{Name: "items", Expression: `["a", "b", "c"]`},
-					},
-					Steps: []ottoflowv1alpha1.Step{
-						{
-							Name: "loop",
-							ForEach: &ottoflowv1alpha1.StepForEach{
-								Items: `variables.items`,
-								Step: &ottoflowv1alpha1.StepForEachStep{
-									Expressions: []ottoflowv1alpha1.Expression{
-										{Name: "boom", Expression: `variables.item == "b" ? variables.item.noSuchField : variables.item`},
-									},
-								},
-								MaxConcurrency:    1,
-								ItemFailurePolicy: ottoflowv1alpha1.FailurePolicyContinue,
-							},
-						},
-					},
-				},
-			}
+			// Only item "b" fails (field access on a string); "a" and "c" succeed.
+			workflow := forEachWorkflow(ottoflowv1alpha1.FailurePolicyContinue, `variables.item == "b" ? variables.item.noSuchField : variables.item`)
 			Expect(workflowExecutor.contextManager.InitializeContext(ctx, workflow, workflowRun.Spec.InputValues)).To(Succeed())
 
 			Expect(workflowExecutor.ExecuteWorkflow(ctx, workflow, workflowRun)).To(Succeed())

--- a/internal/workflow/executor/foreach_executor_test.go
+++ b/internal/workflow/executor/foreach_executor_test.go
@@ -639,18 +639,87 @@ var _ = Describe("ForEach Executor", func() {
 			Expect(workflowRun.Status.StepStatuses["loop"].Phase).To(Equal(ottoflowv1alpha1.StepPhaseFailed))
 		})
 
-		It("succeeds but records the tally when itemFailurePolicy is Continue", func() {
+		It("fails the step when every item fails under itemFailurePolicy=Continue", func() {
 			workflow := alwaysFailingForEach(ottoflowv1alpha1.FailurePolicyContinue)
 			Expect(workflowExecutor.contextManager.InitializeContext(ctx, workflow, workflowRun.Spec.InputValues)).To(Succeed())
 
-			// Continue is documented to collect failures and carry on, so the step succeeds.
-			// What must not happen is a fully-failed loop looking identical to a clean one.
-			Expect(workflowExecutor.ExecuteWorkflow(ctx, workflow, workflowRun)).To(Succeed())
-			Expect(workflowRun.Status.StepStatuses["loop"].Phase).To(Equal(ottoflowv1alpha1.StepPhaseSucceeded))
-			Expect(workflowRun.Status.StepStatuses["loop"].Message).To(Equal("0/3 items succeeded, 3 failed"))
+			// Continue tolerates partial failure, but a loop where every item failed must
+			// never report success -- that would be a false green. It must not look identical
+			// to a clean run.
+			err := workflowExecutor.ExecuteWorkflow(ctx, workflow, workflowRun)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("all 3 item(s) failed"))
+			Expect(workflowRun.Status.StepStatuses["loop"].Phase).To(Equal(ottoflowv1alpha1.StepPhaseFailed))
 
+			// Failures remain available in context for debugging even though the step failed.
 			failed := workflowExecutor.contextManager.GetContext()["steps"].(map[string]interface{})["loop"].(map[string]interface{})["failed"].([]interface{})
 			Expect(failed).To(HaveLen(3))
+		})
+
+		It("stays Succeeded with an accurate tally when only some items fail under itemFailurePolicy=Continue", func() {
+			// Only item "b" fails (field access on a string); "a" and "c" succeed. MaxConcurrency=1
+			// keeps this deterministic so the tally below is stable regardless of completion order.
+			workflow := &ottoflowv1alpha1.Workflow{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-workflow", Namespace: "default"},
+				Spec: ottoflowv1alpha1.WorkflowSpec{
+					Variables: []ottoflowv1alpha1.Variable{
+						{Name: "items", Expression: `["a", "b", "c"]`},
+					},
+					Steps: []ottoflowv1alpha1.Step{
+						{
+							Name: "loop",
+							ForEach: &ottoflowv1alpha1.StepForEach{
+								Items: `variables.items`,
+								Step: &ottoflowv1alpha1.StepForEachStep{
+									Expressions: []ottoflowv1alpha1.Expression{
+										{Name: "boom", Expression: `variables.item == "b" ? variables.item.noSuchField : variables.item`},
+									},
+								},
+								MaxConcurrency:    1,
+								ItemFailurePolicy: ottoflowv1alpha1.FailurePolicyContinue,
+							},
+						},
+					},
+				},
+			}
+			Expect(workflowExecutor.contextManager.InitializeContext(ctx, workflow, workflowRun.Spec.InputValues)).To(Succeed())
+
+			Expect(workflowExecutor.ExecuteWorkflow(ctx, workflow, workflowRun)).To(Succeed())
+			Expect(workflowRun.Status.StepStatuses["loop"].Phase).To(Equal(ottoflowv1alpha1.StepPhaseSucceeded))
+			Expect(workflowRun.Status.StepStatuses["loop"].Message).To(Equal("2/3 items succeeded, 1 failed"))
+
+			failed := workflowExecutor.contextManager.GetContext()["steps"].(map[string]interface{})["loop"].(map[string]interface{})["failed"].([]interface{})
+			Expect(failed).To(HaveLen(1))
+		})
+
+		It("fails the step when stepTemplateRef resolution fails for every item", func() {
+			// No StepTemplate named "does-not-exist" is registered with the fake client, so
+			// every item fails during template resolution before the child step ever runs.
+			workflow := &ottoflowv1alpha1.Workflow{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-workflow", Namespace: "default"},
+				Spec: ottoflowv1alpha1.WorkflowSpec{
+					Variables: []ottoflowv1alpha1.Variable{
+						{Name: "items", Expression: `["a", "b"]`},
+					},
+					Steps: []ottoflowv1alpha1.Step{
+						{
+							Name: "loop",
+							ForEach: &ottoflowv1alpha1.StepForEach{
+								Items: `variables.items`,
+								StepTemplateRef: &ottoflowv1alpha1.StepForEachTemplateRef{
+									Name: "does-not-exist",
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(workflowExecutor.contextManager.InitializeContext(ctx, workflow, workflowRun.Spec.InputValues)).To(Succeed())
+
+			err := workflowExecutor.ExecuteWorkflow(ctx, workflow, workflowRun)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("all 2 item(s) failed"))
+			Expect(workflowRun.Status.StepStatuses["loop"].Phase).To(Equal(ottoflowv1alpha1.StepPhaseFailed))
 		})
 	})
 

--- a/internal/workflow/executor/foreach_failure_error_test.go
+++ b/internal/workflow/executor/foreach_failure_error_test.go
@@ -1,0 +1,74 @@
+package executor
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestForeachFailureError pins the message chosen for each relationship between the number
+// of items requested and the number that recorded a failure. The middle case -- some items
+// failed and the rest never recorded a result because the context was cancelled mid-loop --
+// is the one a review flagged: it must not claim "all N failed".
+func TestForeachFailureError(t *testing.T) {
+	tests := []struct {
+		name         string
+		requested    int
+		failed       int
+		firstFailure string
+		wantContains []string
+		wantAbsent   []string
+	}{
+		{
+			name:         "every item ran and failed",
+			requested:    3,
+			failed:       3,
+			firstFailure: "boom",
+			wantContains: []string{"all 3 item(s) failed", "itemFailurePolicy=Continue", "boom"},
+			wantAbsent:   []string{"did not complete"},
+		},
+		{
+			name:         "some failed, rest cancelled mid-loop",
+			requested:    3,
+			failed:       1,
+			firstFailure: "boom",
+			wantContains: []string{"1 of 3 item(s) failed", "2 did not complete", "loop cancelled or incomplete", "boom"},
+			wantAbsent:   []string{"all 3 item(s) failed"},
+		},
+		{
+			name:         "nothing recorded a result",
+			requested:    3,
+			failed:       0,
+			firstFailure: "",
+			wantContains: []string{"no items completed successfully", "3 item(s) requested"},
+			wantAbsent:   []string{"did not complete", "item(s) failed"},
+		},
+		{
+			name:         "single item, ran and failed",
+			requested:    1,
+			failed:       1,
+			firstFailure: "kaboom",
+			wantContains: []string{"all 1 item(s) failed", "kaboom"},
+			wantAbsent:   []string{"did not complete"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := foreachFailureError(tt.requested, tt.failed, "Continue", tt.firstFailure)
+			if err == nil {
+				t.Fatal("expected an error, got nil")
+			}
+			msg := err.Error()
+			for _, want := range tt.wantContains {
+				if !strings.Contains(msg, want) {
+					t.Errorf("message %q missing expected substring %q", msg, want)
+				}
+			}
+			for _, absent := range tt.wantAbsent {
+				if strings.Contains(msg, absent) {
+					t.Errorf("message %q should not contain %q", msg, absent)
+				}
+			}
+		})
+	}
+}

--- a/samples/workflows/features/advanced-field-paths.yaml
+++ b/samples/workflows/features/advanced-field-paths.yaml
@@ -1,7 +1,7 @@
 apiVersion: ottoflow.nirmata.io/v1alpha1
 kind: Workflow
 metadata:
-  name: cel-expressions-example
+  name: advanced-field-paths-example
   namespace: ottoflow
 spec:
   inputs:


### PR DESCRIPTION
## Problem

Two issues let a completely non-functional workflow look healthy:

1. A `forEach` step that failed **every** item still reported success. With the default `itemFailurePolicy: Continue`, a loop where 0 of N items succeeded set the step and the WorkflowRun to `Succeeded` and exited 0 — indistinguishable from a clean run. (A partially-failed loop, e.g. 23/26, was and remains a legitimate success.)

2. `ottoflow validate --workflow-dir` performed **no** reference checks. Reference-existence validation only ran with a live cluster client, so local validation passed workflows referencing a `stepTemplateRef` / `agentRef` / `mcpServer` / `workflowRef` that isn't present in the loaded manifests — e.g. a StepTemplate defined in a sibling directory that wasn't loaded, or a WorkflowRun pointing at a workflow name that doesn't exist.

## Changes

- **Executor:** `executeForEach` now returns an error when the loop had items but none succeeded, regardless of `itemFailurePolicy`. The step and run are marked `Failed` and the CLI/runner exit non-zero. Partial success is unchanged. Authors who intend a fully-failed loop to proceed can set the step-level `failurePolicy: Continue`.
- **Validate:** `ottoflow validate --workflow-dir` now resolves references — `stepTemplateRef` (direct and inside `forEach`), `agentRef`, `mcpServer`, and each loaded WorkflowRun's `workflowRef` — against the loaded manifests, using the same namespace defaulting as execution, and fails with a message naming the missing object. (Inline `forEach.step` references and one level into a referenced StepTemplate's own references are also checked.)
- **Sample:** fixes `samples/workflows/features/advanced-field-paths.yaml`, whose WorkflowRun referenced a workflow name that didn't exist.
- **Docs:** correct a few stale references caught during review — the Helm chart READMEs' Kubernetes minimum (`1.20+` → `1.29+`, matching the rest of the docs and the envtest version), the `--namespace` description in `docs/user/reference/configuration.md` (in local `--workflow-dir` mode it only disambiguates same-named workflows; it need not match the workflow's `metadata.namespace`), and the stale sample-count claim in the tasks README.

## Behavior change

All-failed `Continue` loops now fail instead of reporting green. This is intentional; the escape hatch for genuinely-tolerated total failure is step-level `failurePolicy: Continue`.

## Testing

- Executor: inverted the test that encoded the old behavior; added 0-success → Failed, partial → Succeeded (correct tally), all-success, resolution-error → Failed, empty-loop → Succeeded.
- Validate: missing vs present for all four reference kinds, plus a namespace-resolution regression.
- `go build ./...`, `go vet ./...`, and the executor/CLI test packages pass. `ottoflow validate --workflow-dir samples` (the CI gate) stays green; sub-directory validations now correctly report cross-directory reference gaps.

