### PR TITLE
build: pin ko, pin the golangci-lint installer, and set GOWORK once

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,11 +46,6 @@ jobs:
           go-version-file: go.mod
           cache-dependency-path: go.sum
 
-      - name: Set up ko
-        uses: ko-build/setup-ko@61b4d1d396f5b2e7d6bb6fefdce3dc38d1a13445 # v0.10
-        with:
-          version: v0.17.1
-
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,11 @@ HELM_VALUES_FILE ?= ""
 HELM_OUTPUT_DIR ?= config/generated
 HELM_OUTPUT_FILE ?= $(HELM_OUTPUT_DIR)/install.yaml
 
+# Every go invocation below builds this module alone. A go.work above the repo
+# root pulls its own replace directives into the build, so a checkout resolves
+# differently depending on where it sits in the caller's filesystem.
+export GOWORK := off
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq ($(shell go env GOBIN),)
 GOBIN=$(shell go env GOPATH)/bin
@@ -66,7 +71,7 @@ help: ## Display this help.
 
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration and CustomResourceDefinition objects.
-	GOWORK=off $(CONTROLLER_GEN) crd:allowDangerousTypes=true webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) crd:allowDangerousTypes=true webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 	@$(MAKE) sync-crds
 
 .PHONY: sync-crds
@@ -82,7 +87,7 @@ sync-crds: ## Sync CRDs from config/crd/bases to charts/ottoflow/crds (source of
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
-	GOWORK=off $(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
+	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
 ##@ Code generation (docs)
 
@@ -465,8 +470,7 @@ CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen-$(CONTROLLER_TOOLS_VERSION)
 ENVTEST ?= $(LOCALBIN)/setup-envtest-$(ENVTEST_VERSION)
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
 CRD_REF_DOCS ?= $(LOCALBIN)/crd-ref-docs
-# Try to use system ko first, fall back to local installation
-KO ?= $(shell which ko 2>/dev/null || echo $(LOCALBIN)/ko-$(KO_VERSION))
+KO ?= $(LOCALBIN)/ko-$(KO_VERSION)
 # Try to use system helm first, fall back to local installation
 HELM ?= $(shell which helm 2>/dev/null || echo $(LOCALBIN)/helm-$(HELM_VERSION))
 
@@ -476,7 +480,7 @@ CONTROLLER_TOOLS_VERSION ?= v0.20.0
 ENVTEST_VERSION ?= release-0.17
 GOLANGCI_LINT_VERSION ?= v2.11.4
 CRD_REF_DOCS_VERSION ?= v0.3.0
-KO_VERSION ?= latest
+KO_VERSION ?= v0.17.1
 HELM_VERSION ?= v3.13.0
 
 .PHONY: kustomize
@@ -497,15 +501,12 @@ $(ENVTEST): $(LOCALBIN)
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	test -s $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION) || { curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(LOCALBIN) $(GOLANGCI_LINT_VERSION) && mv $(LOCALBIN)/golangci-lint $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION) ; }
+	test -s $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION) || { curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/$(GOLANGCI_LINT_VERSION)/install.sh | sh -s -- -b $(LOCALBIN) $(GOLANGCI_LINT_VERSION) && mv $(LOCALBIN)/golangci-lint $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION) ; }
 
 .PHONY: ko
 ko: $(KO) ## Download ko locally if necessary.
 $(KO): $(LOCALBIN)
-	@if [ "$(shell which ko 2>/dev/null)" = "" ]; then \
-		echo "Installing ko..."; \
-		GOBIN=$(LOCALBIN) go install github.com/google/ko@$(KO_VERSION) && mv $(LOCALBIN)/ko $(LOCALBIN)/ko-$(KO_VERSION); \
-	fi
+	test -s $(LOCALBIN)/ko-$(KO_VERSION) || { GOBIN=$(LOCALBIN) go install github.com/google/ko@$(KO_VERSION) && mv $(LOCALBIN)/ko $(LOCALBIN)/ko-$(KO_VERSION) ; }
 
 .PHONY: crd-ref-docs
 crd-ref-docs: $(CRD_REF_DOCS) ## Download elastic/crd-ref-docs locally if necessary.


### PR DESCRIPTION
Part of #15 — the "unpinned toolchain" and "GOWORK" items. The chart-values items in that issue (`values.schema.json`, dead `crds.*`) are deliberately left out; see the end.

## ko had three pins that could not agree

| Where | Version |
| --- | --- |
| `Makefile` | `KO_VERSION ?= latest` |
| `.github/workflows/release.yaml` (`setup-ko`) | `v0.17.1` |
| `KO ?= $(shell which ko …)` | whatever is on the developer's PATH |

The third one decides: whichever of the other two installed a binary, anyone with `ko` already on PATH used theirs. ko stamps the image it produces, so this is not cosmetic — two people running `make ko-build` on the same commit could produce differently stamped images, and neither would match a release.

`KO_VERSION` is now `v0.17.1` — what the release workflow has actually been building with, so **no published image changes** — and `KO` resolves to the version-suffixed path under `bin/` like `kustomize`, `controller-gen`, `envtest` and `crd-ref-docs` already do.

I removed `setup-ko` from the release workflow rather than bumping it to match, on the reasoning that a second pin is the thing that broke here. Registry auth comes from `docker/login-action`, not from `setup-ko`, so nothing else depended on it, and `go install` is already how every other tool in this Makefile arrives. **Say if you would rather keep `setup-ko` and delete the Makefile's install path instead** — either is one source of truth. What I would avoid is keeping both.

## golangci-lint pinned the version, not the installer

```make
curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(LOCALBIN) $(GOLANGCI_LINT_VERSION)
```

The version landing in `bin/` was right; the script that put it there was whatever `master` held that day. It now comes from the tag being installed.

## GOWORK, once rather than fourteen times

The issue suggests a one-line fix per target. There are 14 bare `go` invocations in the Makefile beyond the two `controller-gen` lines that already set it, which makes that a fix repeated 14 times and forgotten on the 15th. One exported assignment covers every target, present and future:

```make
export GOWORK := off
```

A Makefile assignment overrides the environment, so an ambient `go.work` no longer reaches these builds. The two inline `GOWORK=off` prefixes come out, leaving one place that decides this.

## Verification

With a `go.work` above the checkout naming a module that does not exist:

```
$ GOWORK=/tmp/hostile.work go build ./cmd/...
go: cannot load module /tmp listed in go.work file: open /tmp/go.mod: no such file or directory

$ GOWORK=/tmp/hostile.work make build
…/bin/golangci-lint-v2.11.4 run
0 issues.
go build -o bin/manager cmd/controller/main.go
```

| Check | Result |
| --- | --- |
| `make ko` from scratch | installs `bin/ko-v0.17.1`, `ko version` reports `v0.17.1` |
| `make -n ko-build-manager` | the pinned path is on the command line, not a host `ko` |
| `make build` | fmt, vet, lint — 0 issues, golangci-lint fetched from the pinned installer |
| `make verify-codegen` | generated files up to date (this is the check that covers dropping the two inline `GOWORK=off` prefixes) |
| `helm lint` / `helm template` | pass |
| `go test ./test/chart/...` | pass |

## What I left out of this PR, and why

**Dead workflows** — already fixed. `docs-preserve.yml` and `tidy-go-modules.yml` are gone from `main`; only `ci.yaml`, `codeql.yml` and `release.yaml` remain. That item can be ticked off #15 without any code.

**`values.schema.json` and the dead `crds.*` values** — these want to land together with the metrics-nesting work in #9, not ahead of it, and I would rather send them as their own PR than bury them here. Two things I confirmed while checking:

- `crds.install` / `crds.mode` do not skip anything. CRDs live in `charts/ottoflow/crds/`, which Helm always installs and cannot gate on values. The only consumer is `templates/crds-install-notes.yaml`, which renders a YAML *comment* — one that says "To skip CRD installation, set crds.install: false". The chart README documents both keys and gives `--set crds.install=false` as a copy-pasteable step for the "CRDs managed outside Helm" flow, which silently does nothing.
- `values.yaml` puts `metrics.*` and `prometheusURL` under `webhook:`, while `templates/servicemonitor.yaml` guards on `.Values.controller.metrics.serviceMonitor.enabled` and `templates/deployment.yaml` reads `.Values.controller.prometheusURL`. So setting the documented `webhook.metrics.serviceMonitor.enabled=true` creates no ServiceMonitor, and `webhook.prometheusURL` never reaches `--prometheus-url`.

`additionalProperties: false` catches all three at install time, which is the leverage #15 claims for it — but only once the schema describes what the templates actually read. Happy to take that next if nobody is on #9.
