### PR TITLE
ci: publish an ottoflow-rc Homebrew formula for prerelease tags

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -60,3 +60,26 @@ brews:
       system "#{bin}/ottoflow", "--help"
     install: |
       bin.install "ottoflow"
+  # Prerelease channel: publishes only on prerelease tags (e.g. v0.1.0-alpha1),
+  # the inverse of the stable entry above (which skips those via skip_upload: auto).
+  - name: ottoflow-rc
+    repository:
+      owner: nirmata
+      name: homebrew-tap
+      token: '{{ .Env.TAP_GITHUB_TOKEN }}'
+    directory: .
+    homepage: https://github.com/nirmata/ottoflow
+    description: 'Release-candidate builds of the OttoFlow CLI'
+    license: BUSL-1.1
+    # Only publish for prerelease tags; skip on stable releases.
+    skip_upload: '{{ if .Prerelease }}false{{ else }}true{{ end }}'
+    conflicts:
+      - ottoflow
+    commit_author:
+      name: nirmata-bot
+      email: bot@nirmata.com
+    commit_msg_template: 'Brew formula update for {{ .ProjectName }}-rc version {{ .Tag }}'
+    test: |
+      system "#{bin}/ottoflow", "--help"
+    install: |
+      bin.install "ottoflow"


### PR DESCRIPTION
## What
Adds a second Homebrew formula, `ottoflow-rc`, so prerelease tags publish an installable formula in `nirmata/homebrew-tap`, without affecting stable installs.

- `brew install nirmata/tap/ottoflow` → latest **stable** (unchanged)
- `brew install nirmata/tap/ottoflow-rc` → latest **release candidate** (new)

## How
`ottoflow-rc` is the inverse of the stable `ottoflow` entry: its `skip_upload` is templated on `.Prerelease`, so it publishes **only** on prerelease tags and skips on stable, while the stable entry keeps `skip_upload: auto`. The two write different files (`ottoflow.rb` vs `ottoflow-rc.rb`) and exactly one publishes per tag, so an RC never overwrites the stable formula. `conflicts_with` prevents installing both at once. No new tap, no workflow/token changes — same tap and `TAP_GITHUB_TOKEN`, mirroring the existing `kyverno-mcp-rc` / `nctl` pattern.

## Verification
`goreleaser check` passes. Full proof requires cutting a `v*-rc*` tag: the RC formula publishes and the stable formula stays put; on a stable tag, the reverse.

## Note
`ottoflow-rc` tracks any prerelease (`-rc`/`-alpha`/`-beta`), matching how the stable formula already treats all prereleases. Can be narrowed to `-rc*` only.
