### PR TITLE
docs: make the pod-triage quickstart deploy failing pods to triage

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,19 @@ For details on the data collection, analysis, and reporting view the [workflow s
 
 ## Execute an AI workflow
 
+### Give it something to triage
+
+`pod-triage` scans the `default` namespace, so on a fresh cluster there's
+nothing failing to look at. Seed a few deliberately-broken pods first:
+
+```sh
+kubectl apply -f https://raw.githubusercontent.com/nirmata/ottoflow/main/samples/fixtures/failing-pods.yaml
+```
+
+This creates a crash-looping (OOMKilled) pod, an ImagePullBackOff pod, and
+two healthy ones — real, differing failures for the workflow to prioritize.
+Clean up afterward with `kubectl delete -f` on the same URL.
+
 ### Pick your LLM provider
 
 `pod-triage` adds an LLM step. The sample's `Agent` defaults to **Gemini** —
@@ -99,25 +112,27 @@ GEMINI_API_KEY=AIza... \
 Use <https://aistudio.google.com/api-keys> to get an API key.
 
 Prefer OpenAI, Anthropic, or no cloud key at all? Override with `--provider`/`--model`
-and the matching environment variable — no editing the workflow required:
+and the matching environment variable — no editing the workflow required. `-n ottoflow`
+only controls where the `Workflow`/`Agent` objects resolve — it does not change which
+namespace `pod-triage` scans, that's still always `default`:
 
 ```sh
 # OpenAI -- OPENAI_API_KEY must be set; --model optional (defaults to gpt-4o)
 OPENAI_API_KEY=sk-... \
-  ottoflow run samples/workflows/production/pod-triage.yaml -n ottoflow --provider openai
+  ottoflow run -f https://raw.githubusercontent.com/nirmata/ottoflow/main/samples/workflows/production/pod-triage.yaml -n ottoflow --provider openai
 ```
 
 ```sh
 # Anthropic -- ANTHROPIC_API_KEY must be set; --model optional (defaults to a current Claude model)
 ANTHROPIC_API_KEY=sk-ant-... \
-  ottoflow run samples/workflows/production/pod-triage.yaml -n ottoflow --provider anthropic
+  ottoflow run -f https://raw.githubusercontent.com/nirmata/ottoflow/main/samples/workflows/production/pod-triage.yaml -n ottoflow --provider anthropic
 ```
 
 ```sh
 # Local -- no cloud key, no cluster data leaves your machine. --model is required
 # here; there is no default local model.
 LLAMACPP_HOST=http://127.0.0.1:11434/ \
-  ottoflow run samples/workflows/production/pod-triage.yaml -n ottoflow \
+  ottoflow run -f https://raw.githubusercontent.com/nirmata/ottoflow/main/samples/workflows/production/pod-triage.yaml -n ottoflow \
   --provider local --model gemma3:4b
 ```
 
@@ -183,6 +198,18 @@ ottoflow run cluster-overview -n ottoflow
 The controller reconciles Workflows/WorkflowRuns and runs the leader-elected
 scheduler; agent steps execute via the agent-executor pod (set LLM keys via
 `agentExecutor.env` in the chart).
+
+With OttoFlow installed in the cluster, root-cause a single failing pod
+(seed the fixture from [above](#give-it-something-to-triage) first):
+
+```sh
+kubectl apply -f samples/workflows/production/workload-troubleshooter.yaml
+ottoflow run workload-troubleshooter --input podName=crashy --input namespace=default -n ottoflow
+```
+
+`workload-troubleshooter` pulls the pod's events and logs and asks the agent
+for a root cause — it needs the in-cluster controller (logs aren't available
+in local `--workflow-dir` mode).
 
 ## 📚 Documentation · Help · Contributing · License
 

--- a/README.md
+++ b/README.md
@@ -112,9 +112,10 @@ GEMINI_API_KEY=AIza... \
 Use <https://aistudio.google.com/api-keys> to get an API key.
 
 Prefer OpenAI, Anthropic, or no cloud key at all? Override with `--provider`/`--model`
-and the matching environment variable — no editing the workflow required. `-n ottoflow`
-only controls where the `Workflow`/`Agent` objects resolve — it does not change which
-namespace `pod-triage` scans, that's still always `default`:
+and the matching environment variable — no editing the workflow required. (`-n ottoflow`
+is optional here: with `-f` the workflow loads under its own `metadata.namespace`, and
+`-n` is only a hint to disambiguate when several same-named workflows are loaded at once.
+Either way it never changes which namespace `pod-triage` scans — that's always `default`.)
 
 ```sh
 # OpenAI -- OPENAI_API_KEY must be set; --model optional (defaults to gpt-4o)
@@ -199,17 +200,12 @@ The controller reconciles Workflows/WorkflowRuns and runs the leader-elected
 scheduler; agent steps execute via the agent-executor pod (set LLM keys via
 `agentExecutor.env` in the chart).
 
-With OttoFlow installed in the cluster, root-cause a single failing pod
-(seed the fixture from [above](#give-it-something-to-triage) first):
-
-```sh
-kubectl apply -f samples/workflows/production/workload-troubleshooter.yaml
-ottoflow run workload-troubleshooter --input podName=crashy --input namespace=default -n ottoflow
-```
-
-`workload-troubleshooter` pulls the pod's events and logs and asks the agent
-for a root cause — it needs the in-cluster controller (logs aren't available
-in local `--workflow-dir` mode).
+For an LLM-driven root cause of a single failing pod — events and logs in, cause
+and remediation out — see
+[`workload-troubleshooter.yaml`](samples/workflows/production/workload-troubleshooter.yaml).
+It's in-cluster only (it needs pod logs, unavailable in local `--workflow-dir`
+mode) and runs the agent on the agent-executor, so it uses the LLM you configured
+there rather than the `--provider`/`--model` flags (which apply to local runs only).
 
 ## 📚 Documentation · Help · Contributing · License
 

--- a/hack/gen-demo-gif.sh
+++ b/hack/gen-demo-gif.sh
@@ -12,7 +12,7 @@
 #       export LLAMACPP_HOST=http://127.0.0.1:11434/
 #
 # It seeds samples/fixtures/failing-pods.yaml (a crash-looping OOMKilled pod, an
-# ImagePullBackOff pod, and a healthy one), waits for the crash-looper to
+# ImagePullBackOff pod, and two healthy ones), waits for the crash-looper to
 # accumulate restarts, records the GIF, then removes the fixture.
 set -euo pipefail
 cd "$(dirname "$0")/.."

--- a/hack/gen-demo-gif.sh
+++ b/hack/gen-demo-gif.sh
@@ -11,7 +11,7 @@
 #   - a llama.cpp-compatible server reachable, with LLAMACPP_HOST exported, e.g.
 #       export LLAMACPP_HOST=http://127.0.0.1:11434/
 #
-# It seeds hack/demo-fixture.yaml (a crash-looping OOMKilled pod, an
+# It seeds samples/fixtures/failing-pods.yaml (a crash-looping OOMKilled pod, an
 # ImagePullBackOff pod, and a healthy one), waits for the crash-looper to
 # accumulate restarts, records the GIF, then removes the fixture.
 set -euo pipefail
@@ -23,8 +23,8 @@ command -v vhs >/dev/null 2>&1 || {
 }
 
 echo "Seeding demo failure pods into namespace 'default'..."
-kubectl apply -f hack/demo-fixture.yaml
-trap 'kubectl delete -f hack/demo-fixture.yaml --ignore-not-found >/dev/null 2>&1 || true' EXIT
+kubectl apply -f samples/fixtures/failing-pods.yaml
+trap 'kubectl delete -f samples/fixtures/failing-pods.yaml --ignore-not-found >/dev/null 2>&1 || true' EXIT
 
 echo "Waiting for 'crashy' to accumulate OOMKilled restarts (>3)..."
 for _ in $(seq 1 60); do

--- a/images/demo.tape
+++ b/images/demo.tape
@@ -2,7 +2,7 @@
 # pod-triage hero for the README GIF (images/demo.gif).
 #
 # Regenerate with: make demo   (runs hack/gen-demo-gif.sh, which seeds
-#   hack/demo-fixture.yaml — crashy=OOMKilled, web-broken=ImagePullBackOff,
+#   samples/fixtures/failing-pods.yaml — crashy=OOMKilled, web-broken=ImagePullBackOff,
 #   healthy-web — waits for the crash-loop, records this tape, then removes it).
 #
 # Prereqs: vhs (brew install vhs), a throwaway cluster with an empty default ns

--- a/images/demo.tape
+++ b/images/demo.tape
@@ -3,7 +3,8 @@
 #
 # Regenerate with: make demo   (runs hack/gen-demo-gif.sh, which seeds
 #   samples/fixtures/failing-pods.yaml — crashy=OOMKilled, web-broken=ImagePullBackOff,
-#   healthy-web — waits for the crash-loop, records this tape, then removes it).
+#   healthy-web + healthy-api — waits for the crash-loop, records this tape, then
+#   removes it).
 #
 # Prereqs: vhs (brew install vhs), a throwaway cluster with an empty default ns
 #   (e.g. kind create cluster), a local model server, and LLAMACPP_HOST exported.

--- a/samples/fixtures/failing-pods.yaml
+++ b/samples/fixtures/failing-pods.yaml
@@ -1,12 +1,10 @@
-# Demo fixture for `make demo` (applied by hack/gen-demo-gif.sh). Seeds four pods
-# so the recorded pod-triage run shows the agent PRIORITIZING across real, differing
-# signals rather than restating one fact. Two fail differently, two are healthy —
-# giving "4 pods scanned, 2 flagged unhealthy", matching the README transcript:
+# Deliberately-broken pods for the README pod-triage quickstart: a
+# crash-looping (OOMKilled) pod, an ImagePullBackOff pod, and two healthy
+# ones. Applied to the `default` namespace because pod-triage scans `default`.
 #   crashy      — OOMKilled crash-looper: restartCount climbs, lastState OOMKilled
 #   web-broken  — ImagePullBackOff: bad image tag, never starts (0 restarts)
 #   healthy-web — healthy; never flagged (proves the filter excludes healthy pods)
 #   healthy-api — healthy; never flagged
-# Applied to namespace "default" because pod-triage's resourceQuery scans default.
 apiVersion: v1
 kind: Pod
 metadata:


### PR DESCRIPTION
## What
The README's "Execute an AI workflow" example runs `pod-triage`, which scans the `default` namespace, but never had the user create any failing pods — so on a fresh cluster the run produced an empty result and the documented "N pods scanned, M flagged" transcript could not reproduce.

## Changes
- Surface the deliberately-broken-pod fixture from `hack/` to a discoverable `samples/fixtures/failing-pods.yaml` (a crash-looping/OOMKilled pod, an ImagePullBackOff pod, and two healthy ones). Single source of truth — the demo GIF script and tape are repointed to it.
- Add a "Give it something to triage" seed step (`kubectl apply` by raw URL) before the `pod-triage` run, so the example has real, differing failures to prioritize.
- Add a cluster-mode `workload-troubleshooter` follow-up in "Install in your cluster" that root-causes a single failing pod from the same fixture.
- Fix the provider-override commands to use the `-f <raw URL>` form (the relative `samples/` path isn't available to a `brew install`-only user).
- Clarify that `-n ottoflow` selects where the Workflow/Agent resolve, not which namespace `pod-triage` scans (it always scans `default`).

No workflow-logic or code changes.

## Verification
`make build-cli` passes; the moved fixture parses; no dangling references remain. The full end-to-end run (apply fixture → wait for CrashLoopBackOff/ImagePullBackOff → run `pod-triage` with an LLM key → confirm the transcript) needs a live cluster + LLM and is being confirmed by a manual run-through.
