### PR TITLE
fix: don't fail toolloop.Run on trailing usage-only stream response

### DIFF
--- a/internal/agent/toolloop/loop.go
+++ b/internal/agent/toolloop/loop.go
@@ -77,7 +77,12 @@ func Run(ctx context.Context, chat gollm.Chat, initialContent []any, toolset map
 			}
 			candidates := response.Candidates()
 			if len(candidates) == 0 {
-				return "", usage, fmt.Errorf("chat response had no candidates")
+				// Some providers (e.g. gollm's Anthropic streaming client) emit a
+				// trailing response that carries only usage metadata and no
+				// content once the stream ends. That's not a broken response --
+				// a genuinely empty/blocked model reply surfaces as streamErr
+				// above, not as a content-less-but-successful event here.
+				continue
 			}
 			for _, part := range candidates[0].Parts() {
 				if t, ok := part.AsText(); ok {

--- a/internal/agent/toolloop/loop_test.go
+++ b/internal/agent/toolloop/loop_test.go
@@ -84,6 +84,14 @@ func (p fakePart) AsFunctionCalls() ([]gollm.FunctionCall, bool) {
 	return p.r.calls, true
 }
 
+// emptyCandidatesResponse simulates gollm's Anthropic streaming client, which
+// yields a trailing response carrying only usage metadata and no
+// text/functionCall once a stream ends (see anthropic.go's SendStreaming).
+type emptyCandidatesResponse struct{ usage any }
+
+func (r emptyCandidatesResponse) UsageMetadata() any            { return r.usage }
+func (r emptyCandidatesResponse) Candidates() []gollm.Candidate { return nil }
+
 // fakeTool is a minimal tools.Tool that records invocations and delegates to runFunc.
 type fakeTool struct {
 	name    string
@@ -245,6 +253,41 @@ func TestRun_SendStreamingError_Propagates(t *testing.T) {
 	_, _, err := Run(context.Background(), chat, []any{"go"}, nil, Options{})
 	if !errors.Is(err, sendErr) {
 		t.Errorf("error = %v, want it to wrap %v", err, sendErr)
+	}
+}
+
+// trailingUsageChat scripts a single SendStreaming call that yields text
+// followed by a trailing usage-only response with zero candidates, matching
+// gollm's Anthropic streaming client's behavior at the end of every stream.
+type trailingUsageChat struct{}
+
+func (c *trailingUsageChat) Send(ctx context.Context, contents ...any) (gollm.ChatResponse, error) {
+	return nil, errors.New("trailingUsageChat.Send not implemented")
+}
+
+func (c *trailingUsageChat) SendStreaming(ctx context.Context, contents ...any) (gollm.ChatResponseIterator, error) {
+	return gollm.ChatResponseIterator(func(yield func(gollm.ChatResponse, error) bool) {
+		if !yield(fakeResponse{text: "the answer"}, nil) {
+			return
+		}
+		yield(emptyCandidatesResponse{usage: map[string]any{"input_tokens": 10, "output_tokens": 5}}, nil)
+	}), nil
+}
+
+func (c *trailingUsageChat) SetFunctionDefinitions(defs []*gollm.FunctionDefinition) error { return nil }
+func (c *trailingUsageChat) IsRetryableError(err error) bool                               { return false }
+func (c *trailingUsageChat) Initialize(messages []*api.Message) error                      { return nil }
+
+func TestRun_TrailingUsageOnlyResponse_SkippedNotFatal(t *testing.T) {
+	text, usage, err := Run(context.Background(), &trailingUsageChat{}, []any{"hello"}, nil, Options{})
+	if err != nil {
+		t.Fatalf("Run returned error: %v, want the trailing zero-candidate usage response to be skipped", err)
+	}
+	if text != "the answer" {
+		t.Errorf("text = %q, want %q", text, "the answer")
+	}
+	if usage == nil {
+		t.Error("expected usage metadata from the trailing response to be captured, got nil")
 	}
 }
 

--- a/internal/agent/toolloop/loop_test.go
+++ b/internal/agent/toolloop/loop_test.go
@@ -274,9 +274,11 @@ func (c *trailingUsageChat) SendStreaming(ctx context.Context, contents ...any) 
 	}), nil
 }
 
-func (c *trailingUsageChat) SetFunctionDefinitions(defs []*gollm.FunctionDefinition) error { return nil }
-func (c *trailingUsageChat) IsRetryableError(err error) bool                               { return false }
-func (c *trailingUsageChat) Initialize(messages []*api.Message) error                      { return nil }
+func (c *trailingUsageChat) SetFunctionDefinitions(defs []*gollm.FunctionDefinition) error {
+	return nil
+}
+func (c *trailingUsageChat) IsRetryableError(err error) bool          { return false }
+func (c *trailingUsageChat) Initialize(messages []*api.Message) error { return nil }
 
 func TestRun_TrailingUsageOnlyResponse_SkippedNotFatal(t *testing.T) {
 	text, usage, err := Run(context.Background(), &trailingUsageChat{}, []any{"hello"}, nil, Options{})


### PR DESCRIPTION
## Summary
- gollm's Anthropic streaming client emits a trailing `ChatResponse` at the end of a stream that carries only usage metadata (token counts) and no text/function-call content.
- `toolloop.Run` treated any response with zero `Candidates()` as a fatal error (`chat response had no candidates`), so every Anthropic-backed agent step failed after successfully streaming its actual answer.
- Now that content-less-but-otherwise-successful event is skipped via `continue` instead of erroring. A genuinely empty/blocked model reply still surfaces via `streamErr`, which is unaffected by this change.

## Test plan
- [x] Added `TestRun_TrailingUsageOnlyResponse_SkippedNotFatal` covering a stream that ends with a usage-only response after real content.
- [x] `go test ./internal/agent/toolloop/...`
- [x] Repro'd against a live workflow: `ottoflow run -f samples/workflows/production/pod-triage.yaml --provider anthropic` failed with `chat response had no candidates` on main; rebuilding from this branch resolves it (workflow then progresses past the agent step to config, e.g. missing `ANTHROPIC_API_KEY`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)