### PR TITLE
fix: update default Gemini model from deprecated gemini-2.5-flash

### DIFF
--- a/internal/agent/default_executor.go
+++ b/internal/agent/default_executor.go
@@ -211,7 +211,7 @@ func (e *DefaultAgentExecutor) getDefaultModel(provider string) string {
 	case providerAzureOpenAI:
 		return "gpt-4o"
 	case providerGoogle, providerGemini:
-		return "gemini-2.5-flash"
+		return "gemini-3.6-flash"
 	default:
 		return ""
 	}

--- a/internal/agent/default_executor_test.go
+++ b/internal/agent/default_executor_test.go
@@ -231,8 +231,8 @@ var _ = Describe("DefaultAgentExecutor getDefaultModel", func() {
 		Expect(e.getDefaultModel("openai")).To(Equal("gpt-4o"))
 		Expect(e.getDefaultModel("anthropic")).To(Equal("claude-opus-5"))
 		Expect(e.getDefaultModel("azure-openai")).To(Equal("gpt-4o"))
-		Expect(e.getDefaultModel("google")).To(Equal("gemini-2.5-flash"))
-		Expect(e.getDefaultModel("gemini")).To(Equal("gemini-2.5-flash"))
+		Expect(e.getDefaultModel("google")).To(Equal("gemini-3.6-flash"))
+		Expect(e.getDefaultModel("gemini")).To(Equal("gemini-3.6-flash"))
 	})
 
 	It("returns empty string for local/unknown/nirmata rather than guessing", func() {

--- a/samples/kagent-quickstart/README.md
+++ b/samples/kagent-quickstart/README.md
@@ -102,7 +102,7 @@ kubectl create secret generic openai-key -n kagent \
 ```yaml
 spec:
   provider: Gemini
-  model: gemini-2.5-flash
+  model: gemini-3.6-flash
   apiKeySecret: gemini-key
   apiKeySecretKey: GEMINI_API_KEY
 ```

--- a/samples/workflows/features/agent-gemini.yaml
+++ b/samples/workflows/features/agent-gemini.yaml
@@ -68,6 +68,6 @@ metadata:
 spec:
   prompt: "You are a helpful AI assistant. Answer questions clearly and concisely."
   modelProvider: google  # "gemini" is an accepted alias for the same provider
-  modelName: gemini-2.5-flash
+  modelName: gemini-3.6-flash
   outputExtraction:
     type: text


### PR DESCRIPTION
## Summary
- `gemini-2.5-flash` is no longer served to new Gemini API keys — Google returns a 404 and points callers to `gemini-3.6-flash`. Anyone following the quick-start README with a fresh key hits this immediately on the `pod-triage` sample.
- Updates `DefaultAgentExecutor.getDefaultModel`'s Gemini/Google default, plus the two sample files (`samples/workflows/features/agent-gemini.yaml`, `samples/kagent-quickstart/README.md`) that pinned the old model name.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/agent/...` (updated `default_executor_test.go` expectations, both pass)
- [ ] Manually re-ran the quick-start `pod-triage` sample against a live Gemini key (reporter confirmed the underlying 404; not re-verified against a live key in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)