### PR TITLE
fix: record workflow metrics in the controller, from run status

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -314,6 +314,12 @@ func main() {
 		}
 	}
 
+	runMetrics := workflowcontroller.NewRunMetrics(mgr.GetCache(), mgr.GetClient())
+	if err := mgr.Add(runMetrics); err != nil {
+		setupLog.Error(err, "unable to add run metrics recorder to manager")
+		os.Exit(1)
+	}
+
 	// Create metrics client (optional - gracefully handles if metrics server not available)
 	var metricsClient metricsclientset.Interface
 	metricsClient, err = metricsclientset.NewForConfig(mgr.GetConfig())

--- a/internal/workflow/controller/run_metrics.go
+++ b/internal/workflow/controller/run_metrics.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2026 Nirmata, Inc.
+
+Use of this source code is governed by the Business Source License 1.1
+that can be found in the LICENSE.md file.
+*/
+
+package controller
+
+import (
+	"context"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	ottoflowv1alpha1 "github.com/nirmata/ottoflow/api/v1alpha1"
+	"github.com/nirmata/ottoflow/internal/metrics"
+)
+
+// activeResyncInterval is how often the active-runs gauge is recomputed.
+const activeResyncInterval = 30 * time.Second
+
+// RunMetrics records the ottoflow_workflow_* metrics from WorkflowRun status.
+//
+// The executor increments them today, but it runs in the runner Job, which
+// serves no HTTP and then exits, so nothing has ever been able to scrape them.
+// Everything they need is already in status, which the runner writes and the
+// controller watches.
+type RunMetrics struct {
+	cache  ctrlcache.Cache
+	client client.Client
+}
+
+func NewRunMetrics(c ctrlcache.Cache, k8s client.Client) *RunMetrics {
+	return &RunMetrics{cache: c, client: k8s}
+}
+
+// NeedLeaderElection keeps one recorder per cluster. Counters are per-process,
+// so every replica recording every run would multiply them by replica count.
+func (m *RunMetrics) NeedLeaderElection() bool { return true }
+
+func (m *RunMetrics) Start(ctx context.Context) error {
+	logger := log.FromContext(ctx).WithName("run-metrics")
+
+	informer, err := m.cache.GetInformer(ctx, &ottoflowv1alpha1.WorkflowRun{})
+	if err != nil {
+		return err
+	}
+	// Only updates are handled. A restart replays every cached run as an add,
+	// and counting those would re-count runs already counted before it.
+	if _, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		UpdateFunc: func(oldObj, newObj any) {
+			old, oldOK := oldObj.(*ottoflowv1alpha1.WorkflowRun)
+			current, newOK := newObj.(*ottoflowv1alpha1.WorkflowRun)
+			if oldOK && newOK {
+				recordRunTransition(old, current)
+			}
+		},
+	}); err != nil {
+		return err
+	}
+
+	ticker := time.NewTicker(activeResyncInterval)
+	defer ticker.Stop()
+	for {
+		if err := m.syncActive(ctx); err != nil {
+			logger.Error(err, "recomputing active runs")
+		}
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+	}
+}
+
+// recordRunTransition records a run that has just reached a terminal phase,
+// and the steps it finished with.
+func recordRunTransition(old, current *ottoflowv1alpha1.WorkflowRun) {
+	if old.Status.Phase == current.Status.Phase || !runIsTerminal(current) {
+		return
+	}
+
+	workflow, namespace := current.Spec.WorkflowRef.Name, current.Namespace
+	metrics.WorkflowRunsTotal.WithLabelValues(workflow, namespace, runResult(current)).Inc()
+	if d, ok := elapsed(current.Status.StartTime, current.Status.CompletionTime); ok {
+		metrics.WorkflowRunDurationSeconds.WithLabelValues(workflow, namespace).Observe(d)
+	}
+
+	for name, step := range current.Status.StepStatuses {
+		metrics.WorkflowStepsTotal.WithLabelValues(workflow, namespace, name, stepResult(step)).Inc()
+		if d, ok := elapsed(step.StartTime, step.CompletionTime); ok {
+			metrics.WorkflowStepDurationSeconds.WithLabelValues(workflow, namespace, name).Observe(d)
+		}
+	}
+}
+
+// syncActive recomputes the active gauge from the cache. A gauge tracked by
+// increments drifts past any event the controller did not see; recomputing it
+// cannot.
+func (m *RunMetrics) syncActive(ctx context.Context) error {
+	var runs ottoflowv1alpha1.WorkflowRunList
+	if err := m.client.List(ctx, &runs); err != nil {
+		return err
+	}
+
+	active := map[[2]string]float64{}
+	for i := range runs.Items {
+		run := &runs.Items[i]
+		key := [2]string{run.Spec.WorkflowRef.Name, run.Namespace}
+		if _, seen := active[key]; !seen {
+			active[key] = 0
+		}
+		if run.Status.Phase == ottoflowv1alpha1.WorkflowRunPhaseRunning {
+			active[key]++
+		}
+	}
+	for key, count := range active {
+		metrics.WorkflowRunsActive.WithLabelValues(key[0], key[1]).Set(count)
+	}
+	return nil
+}
+
+func runResult(run *ottoflowv1alpha1.WorkflowRun) string {
+	if run.Status.Phase == ottoflowv1alpha1.WorkflowRunPhaseSucceeded {
+		return "succeeded"
+	}
+	return "failed"
+}
+
+func stepResult(step ottoflowv1alpha1.StepStatus) string {
+	switch step.Phase {
+	case ottoflowv1alpha1.StepPhaseSucceeded:
+		return "succeeded"
+	case ottoflowv1alpha1.StepPhaseSkipped:
+		return "skipped"
+	default:
+		return "failed"
+	}
+}
+
+func elapsed(start, end *metav1.Time) (float64, bool) {
+	if start == nil || end == nil || start.IsZero() || end.IsZero() {
+		return 0, false
+	}
+	d := end.Sub(start.Time)
+	if d < 0 {
+		return 0, false
+	}
+	return d.Seconds(), true
+}

--- a/internal/workflow/controller/run_metrics.go
+++ b/internal/workflow/controller/run_metrics.go
@@ -33,10 +33,14 @@ const activeResyncInterval = 30 * time.Second
 type RunMetrics struct {
 	cache  ctrlcache.Cache
 	client client.Client
+	// seen is every label set the gauge has reported, so one whose runs have
+	// all been deleted can be dropped instead of reporting its last value
+	// forever. Only syncActive touches it, from one goroutine.
+	seen map[[2]string]struct{}
 }
 
 func NewRunMetrics(c ctrlcache.Cache, k8s client.Client) *RunMetrics {
-	return &RunMetrics{cache: c, client: k8s}
+	return &RunMetrics{cache: c, client: k8s, seen: map[[2]string]struct{}{}}
 }
 
 // NeedLeaderElection keeps one recorder per cluster. Counters are per-process,
@@ -87,16 +91,33 @@ func recordRunTransition(old, current *ottoflowv1alpha1.WorkflowRun) {
 
 	workflow, namespace := current.Spec.WorkflowRef.Name, current.Namespace
 	metrics.WorkflowRunsTotal.WithLabelValues(workflow, namespace, runResult(current)).Inc()
-	if d, ok := elapsed(current.Status.StartTime, current.Status.CompletionTime); ok {
+	if d, ok := elapsed(current.Status.StartTime, runCompletion(current)); ok {
 		metrics.WorkflowRunDurationSeconds.WithLabelValues(workflow, namespace).Observe(d)
 	}
 
 	for name, step := range current.Status.StepStatuses {
-		metrics.WorkflowStepsTotal.WithLabelValues(workflow, namespace, name, stepResult(step)).Inc()
+		result, ran := stepResult(step)
+		if !ran {
+			continue
+		}
+		metrics.WorkflowStepsTotal.WithLabelValues(workflow, namespace, name, result).Inc()
 		if d, ok := elapsed(step.StartTime, step.CompletionTime); ok {
 			metrics.WorkflowStepDurationSeconds.WithLabelValues(workflow, namespace, name).Observe(d)
 		}
 	}
+}
+
+// runCompletion is when the run finished. A failing run is persisted through
+// persistExecutionFailure, which sets only the execution completion time, so
+// reading the top-level one alone drops the duration of every failure.
+func runCompletion(run *ottoflowv1alpha1.WorkflowRun) *metav1.Time {
+	if run.Status.CompletionTime != nil {
+		return run.Status.CompletionTime
+	}
+	if run.Status.Execution != nil {
+		return run.Status.Execution.CompletionTime
+	}
+	return nil
 }
 
 // syncActive recomputes the active gauge from the cache. A gauge tracked by
@@ -121,6 +142,13 @@ func (m *RunMetrics) syncActive(ctx context.Context) error {
 	}
 	for key, count := range active {
 		metrics.WorkflowRunsActive.WithLabelValues(key[0], key[1]).Set(count)
+		m.seen[key] = struct{}{}
+	}
+	for key := range m.seen {
+		if _, present := active[key]; !present {
+			metrics.WorkflowRunsActive.DeleteLabelValues(key[0], key[1])
+			delete(m.seen, key)
+		}
 	}
 	return nil
 }
@@ -132,14 +160,20 @@ func runResult(run *ottoflowv1alpha1.WorkflowRun) string {
 	return "failed"
 }
 
-func stepResult(step ottoflowv1alpha1.StepStatus) string {
+// stepResult reports how a step ended, and whether it ended at all. Every
+// declared step is initialized to Pending before execution, so a run that fails
+// early leaves its downstream steps sitting there: counting those as failures
+// would put steps that never ran into the failure rate.
+func stepResult(step ottoflowv1alpha1.StepStatus) (result string, ran bool) {
 	switch step.Phase {
 	case ottoflowv1alpha1.StepPhaseSucceeded:
-		return "succeeded"
+		return "succeeded", true
 	case ottoflowv1alpha1.StepPhaseSkipped:
-		return "skipped"
+		return "skipped", true
+	case ottoflowv1alpha1.StepPhaseFailed:
+		return "failed", true
 	default:
-		return "failed"
+		return "", false
 	}
 }
 

--- a/internal/workflow/controller/run_metrics.go
+++ b/internal/workflow/controller/run_metrics.go
@@ -85,7 +85,11 @@ func (m *RunMetrics) Start(ctx context.Context) error {
 // recordRunTransition records a run that has just reached a terminal phase,
 // and the steps it finished with.
 func recordRunTransition(old, current *ottoflowv1alpha1.WorkflowRun) {
-	if old.Status.Phase == current.Status.Phase || !runIsTerminal(current) {
+	// Only the crossing into a terminal phase counts. Requiring the old phase
+	// to be non-terminal keeps a terminal-to-terminal update from counting the
+	// run twice — a cron run marked Failed for Replace whose runner then
+	// persists Succeeded is one.
+	if runIsTerminal(old) || !runIsTerminal(current) {
 		return
 	}
 

--- a/internal/workflow/controller/run_metrics_test.go
+++ b/internal/workflow/controller/run_metrics_test.go
@@ -63,10 +63,10 @@ func histogramCount(t *testing.T, vec *prometheus.HistogramVec, labels ...string
 	return m.GetHistogram().GetSampleCount()
 }
 
-func gaugeValue(t *testing.T, workflow, namespace string) float64 {
+func gaugeValue(t *testing.T, namespace string) float64 {
 	t.Helper()
 	var m dto.Metric
-	g, err := metrics.WorkflowRunsActive.GetMetricWithLabelValues(workflow, namespace)
+	g, err := metrics.WorkflowRunsActive.GetMetricWithLabelValues("wf", namespace)
 	if err != nil {
 		t.Fatalf("gauge: %v", err)
 	}
@@ -147,7 +147,7 @@ func TestSyncActiveCountsRunningRuns(t *testing.T) {
 	if err := m.syncActive(context.Background()); err != nil {
 		t.Fatalf("syncActive: %v", err)
 	}
-	if got := gaugeValue(t, "wf", "default"); got != 2 {
+	if got := gaugeValue(t, "default"); got != 2 {
 		t.Errorf("runs_active = %v, want 2", got)
 	}
 }
@@ -164,7 +164,7 @@ func TestSyncActiveClearsFinishedWorkflows(t *testing.T) {
 	if err := m.syncActive(context.Background()); err != nil {
 		t.Fatalf("syncActive: %v", err)
 	}
-	if got := gaugeValue(t, "wf", "default"); got != 0 {
+	if got := gaugeValue(t, "default"); got != 0 {
 		t.Errorf("runs_active = %v, want 0", got)
 	}
 }
@@ -227,7 +227,7 @@ func TestSyncActiveDropsVanishedWorkflows(t *testing.T) {
 	if err := m.syncActive(context.Background()); err != nil {
 		t.Fatalf("syncActive: %v", err)
 	}
-	if got := gaugeValue(t, "wf", "default"); got != 1 {
+	if got := gaugeValue(t, "default"); got != 1 {
 		t.Fatalf("runs_active = %v, want 1", got)
 	}
 
@@ -237,7 +237,7 @@ func TestSyncActiveDropsVanishedWorkflows(t *testing.T) {
 	if err := m.syncActive(context.Background()); err != nil {
 		t.Fatalf("syncActive: %v", err)
 	}
-	if got := gaugeValue(t, "wf", "default"); got != 0 {
+	if got := gaugeValue(t, "default"); got != 0 {
 		t.Errorf("runs_active = %v after the last run was deleted, want the series gone", got)
 	}
 }

--- a/internal/workflow/controller/run_metrics_test.go
+++ b/internal/workflow/controller/run_metrics_test.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2026 Nirmata, Inc.
+
+Use of this source code is governed by the Business Source License 1.1
+that can be found in the LICENSE.md file.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	ottoflowv1alpha1 "github.com/nirmata/ottoflow/api/v1alpha1"
+	"github.com/nirmata/ottoflow/internal/metrics"
+)
+
+func run(name string, phase ottoflowv1alpha1.WorkflowRunPhase) *ottoflowv1alpha1.WorkflowRun {
+	start := metav1.NewTime(time.Unix(1000, 0))
+	end := metav1.NewTime(time.Unix(1012, 0))
+	return &ottoflowv1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: name},
+		Spec: ottoflowv1alpha1.WorkflowRunSpec{
+			WorkflowRef: ottoflowv1alpha1.WorkflowRef{Name: "wf", Namespace: "default"},
+		},
+		Status: ottoflowv1alpha1.WorkflowRunStatus{
+			Phase:          phase,
+			StartTime:      &start,
+			CompletionTime: &end,
+		},
+	}
+}
+
+func counterValue(t *testing.T, vec *prometheus.CounterVec, labels ...string) float64 {
+	t.Helper()
+	var m dto.Metric
+	c, err := vec.GetMetricWithLabelValues(labels...)
+	if err != nil {
+		t.Fatalf("counter %v: %v", labels, err)
+	}
+	if err := c.Write(&m); err != nil {
+		t.Fatalf("writing counter %v: %v", labels, err)
+	}
+	return m.GetCounter().GetValue()
+}
+
+func histogramCount(t *testing.T, vec *prometheus.HistogramVec, labels ...string) uint64 {
+	t.Helper()
+	var m dto.Metric
+	o, err := vec.GetMetricWithLabelValues(labels...)
+	if err != nil {
+		t.Fatalf("histogram %v: %v", labels, err)
+	}
+	if err := o.(prometheus.Metric).Write(&m); err != nil {
+		t.Fatalf("writing histogram %v: %v", labels, err)
+	}
+	return m.GetHistogram().GetSampleCount()
+}
+
+func gaugeValue(t *testing.T, workflow, namespace string) float64 {
+	t.Helper()
+	var m dto.Metric
+	g, err := metrics.WorkflowRunsActive.GetMetricWithLabelValues(workflow, namespace)
+	if err != nil {
+		t.Fatalf("gauge: %v", err)
+	}
+	if err := g.Write(&m); err != nil {
+		t.Fatalf("writing gauge: %v", err)
+	}
+	return m.GetGauge().GetValue()
+}
+
+func TestRecordRunTransition(t *testing.T) {
+	succeeded := run("r1", ottoflowv1alpha1.WorkflowRunPhaseSucceeded)
+	before := counterValue(t, metrics.WorkflowRunsTotal, "wf", "default", "succeeded")
+	durations := histogramCount(t, metrics.WorkflowRunDurationSeconds, "wf", "default")
+
+	recordRunTransition(run("r1", ottoflowv1alpha1.WorkflowRunPhaseRunning), succeeded)
+
+	if got := counterValue(t, metrics.WorkflowRunsTotal, "wf", "default", "succeeded"); got != before+1 {
+		t.Errorf("runs_total = %v, want %v", got, before+1)
+	}
+	if got := histogramCount(t, metrics.WorkflowRunDurationSeconds, "wf", "default"); got != durations+1 {
+		t.Errorf("run duration observations = %d, want %d", got, durations+1)
+	}
+}
+
+// Reaching a terminal phase is what counts, not being in one. A re-sent update
+// for an already-finished run must not count it twice.
+func TestRecordRunTransitionIgnoresRepeats(t *testing.T) {
+	terminal := run("r2", ottoflowv1alpha1.WorkflowRunPhaseFailed)
+	before := counterValue(t, metrics.WorkflowRunsTotal, "wf", "default", "failed")
+
+	recordRunTransition(terminal, terminal)
+	recordRunTransition(run("r2", ottoflowv1alpha1.WorkflowRunPhaseRunning), run("r2", ottoflowv1alpha1.WorkflowRunPhaseRunning))
+
+	if got := counterValue(t, metrics.WorkflowRunsTotal, "wf", "default", "failed"); got != before {
+		t.Errorf("runs_total = %v, want it unchanged at %v", got, before)
+	}
+}
+
+// Step metrics come out of status, which is how they cross the runner Job
+// boundary at all.
+func TestRecordRunTransitionRecordsSteps(t *testing.T) {
+	start := metav1.NewTime(time.Unix(2000, 0))
+	end := metav1.NewTime(time.Unix(2003, 0))
+	finished := run("r3", ottoflowv1alpha1.WorkflowRunPhaseSucceeded)
+	finished.Status.StepStatuses = map[string]ottoflowv1alpha1.StepStatus{
+		"collect": {Phase: ottoflowv1alpha1.StepPhaseSucceeded, StartTime: &start, CompletionTime: &end},
+		"notify":  {Phase: ottoflowv1alpha1.StepPhaseSkipped},
+		"publish": {Phase: ottoflowv1alpha1.StepPhaseFailed, StartTime: &start, CompletionTime: &end},
+	}
+
+	base := map[string]float64{}
+	for step, result := range map[string]string{"collect": "succeeded", "notify": "skipped", "publish": "failed"} {
+		base[step] = counterValue(t, metrics.WorkflowStepsTotal, "wf", "default", step, result)
+	}
+
+	recordRunTransition(run("r3", ottoflowv1alpha1.WorkflowRunPhaseRunning), finished)
+
+	for step, result := range map[string]string{"collect": "succeeded", "notify": "skipped", "publish": "failed"} {
+		if got := counterValue(t, metrics.WorkflowStepsTotal, "wf", "default", step, result); got != base[step]+1 {
+			t.Errorf("steps_total[%s=%s] = %v, want %v", step, result, got, base[step]+1)
+		}
+	}
+
+	// A skipped step never ran, so it has no duration to observe.
+	if got := histogramCount(t, metrics.WorkflowStepDurationSeconds, "wf", "default", "notify"); got != 0 {
+		t.Errorf("skipped step recorded %d duration observations, want 0", got)
+	}
+}
+
+func TestSyncActiveCountsRunningRuns(t *testing.T) {
+	k8s := fake.NewClientBuilder().WithScheme(newMCPTestScheme(t)).WithObjects(
+		run("a", ottoflowv1alpha1.WorkflowRunPhaseRunning),
+		run("b", ottoflowv1alpha1.WorkflowRunPhaseRunning),
+		run("c", ottoflowv1alpha1.WorkflowRunPhaseSucceeded),
+	).Build()
+	m := NewRunMetrics(nil, k8s)
+
+	if err := m.syncActive(context.Background()); err != nil {
+		t.Fatalf("syncActive: %v", err)
+	}
+	if got := gaugeValue(t, "wf", "default"); got != 2 {
+		t.Errorf("runs_active = %v, want 2", got)
+	}
+}
+
+// The gauge is recomputed rather than decremented, so a workflow whose runs
+// have all finished reads zero instead of holding its last value.
+func TestSyncActiveClearsFinishedWorkflows(t *testing.T) {
+	k8s := fake.NewClientBuilder().WithScheme(newMCPTestScheme(t)).WithObjects(
+		run("d", ottoflowv1alpha1.WorkflowRunPhaseSucceeded),
+	).Build()
+	m := NewRunMetrics(nil, k8s)
+
+	metrics.WorkflowRunsActive.WithLabelValues("wf", "default").Set(5)
+	if err := m.syncActive(context.Background()); err != nil {
+		t.Fatalf("syncActive: %v", err)
+	}
+	if got := gaugeValue(t, "wf", "default"); got != 0 {
+		t.Errorf("runs_active = %v, want 0", got)
+	}
+}

--- a/internal/workflow/controller/run_metrics_test.go
+++ b/internal/workflow/controller/run_metrics_test.go
@@ -103,6 +103,15 @@ func TestRecordRunTransitionIgnoresRepeats(t *testing.T) {
 	if got := counterValue(t, metrics.WorkflowRunsTotal, "wf", "default", "failed"); got != before {
 		t.Errorf("runs_total = %v, want it unchanged at %v", got, before)
 	}
+
+	// One terminal phase replacing another is still not a run finishing: a
+	// cron run marked Failed for Replace whose runner then persists Succeeded
+	// has already been counted.
+	succeededBefore := counterValue(t, metrics.WorkflowRunsTotal, "wf", "default", "succeeded")
+	recordRunTransition(terminal, run("r2", ottoflowv1alpha1.WorkflowRunPhaseSucceeded))
+	if got := counterValue(t, metrics.WorkflowRunsTotal, "wf", "default", "succeeded"); got != succeededBefore {
+		t.Errorf("runs_total[succeeded] = %v after a terminal-to-terminal change, want %v", got, succeededBefore)
+	}
 }
 
 // Step metrics come out of status, which is how they cross the runner Job

--- a/internal/workflow/controller/run_metrics_test.go
+++ b/internal/workflow/controller/run_metrics_test.go
@@ -168,3 +168,76 @@ func TestSyncActiveClearsFinishedWorkflows(t *testing.T) {
 		t.Errorf("runs_active = %v, want 0", got)
 	}
 }
+
+// A run that fails partway leaves its downstream steps at Pending, because
+// every declared step is initialized before execution. Counting those as
+// failures would put steps that never ran into the failure rate.
+func TestRecordRunTransitionSkipsStepsThatNeverRan(t *testing.T) {
+	start := metav1.NewTime(time.Unix(3000, 0))
+	end := metav1.NewTime(time.Unix(3002, 0))
+	failed := run("r4", ottoflowv1alpha1.WorkflowRunPhaseFailed)
+	failed.Status.StepStatuses = map[string]ottoflowv1alpha1.StepStatus{
+		"ran":     {Phase: ottoflowv1alpha1.StepPhaseFailed, StartTime: &start, CompletionTime: &end},
+		"pending": {Phase: ottoflowv1alpha1.StepPhasePending},
+		"waiting": {Phase: ottoflowv1alpha1.StepPhaseWaiting},
+		"running": {Phase: ottoflowv1alpha1.StepPhaseRunning},
+	}
+
+	before := map[string]float64{}
+	for _, step := range []string{"pending", "waiting", "running"} {
+		before[step] = counterValue(t, metrics.WorkflowStepsTotal, "wf", "default", step, "failed")
+	}
+	ranBefore := counterValue(t, metrics.WorkflowStepsTotal, "wf", "default", "ran", "failed")
+
+	recordRunTransition(run("r4", ottoflowv1alpha1.WorkflowRunPhaseRunning), failed)
+
+	for _, step := range []string{"pending", "waiting", "running"} {
+		if got := counterValue(t, metrics.WorkflowStepsTotal, "wf", "default", step, "failed"); got != before[step] {
+			t.Errorf("step %q counted as failed (%v), want unchanged at %v", step, got, before[step])
+		}
+	}
+	if got := counterValue(t, metrics.WorkflowStepsTotal, "wf", "default", "ran", "failed"); got != ranBefore+1 {
+		t.Errorf("the step that did fail = %v, want %v", got, ranBefore+1)
+	}
+}
+
+// A failing run is persisted with only an execution completion time, so
+// reading the top-level one alone drops the duration of every failure.
+func TestRecordRunTransitionUsesExecutionCompletionTime(t *testing.T) {
+	end := metav1.NewTime(time.Unix(1020, 0))
+	failed := run("r5", ottoflowv1alpha1.WorkflowRunPhaseFailed)
+	failed.Status.CompletionTime = nil
+	failed.Status.Execution = &ottoflowv1alpha1.WorkflowRunExecutionStatus{CompletionTime: &end}
+
+	before := histogramCount(t, metrics.WorkflowRunDurationSeconds, "wf", "default")
+	recordRunTransition(run("r5", ottoflowv1alpha1.WorkflowRunPhaseRunning), failed)
+
+	if got := histogramCount(t, metrics.WorkflowRunDurationSeconds, "wf", "default"); got != before+1 {
+		t.Errorf("failed run duration observations = %d, want %d", got, before+1)
+	}
+}
+
+// A workflow whose runs are all gone stops being reported, rather than holding
+// its last value for as long as the process lives.
+func TestSyncActiveDropsVanishedWorkflows(t *testing.T) {
+	running := run("e", ottoflowv1alpha1.WorkflowRunPhaseRunning)
+	k8s := fake.NewClientBuilder().WithScheme(newMCPTestScheme(t)).WithObjects(running).Build()
+	m := NewRunMetrics(nil, k8s)
+
+	if err := m.syncActive(context.Background()); err != nil {
+		t.Fatalf("syncActive: %v", err)
+	}
+	if got := gaugeValue(t, "wf", "default"); got != 1 {
+		t.Fatalf("runs_active = %v, want 1", got)
+	}
+
+	if err := k8s.Delete(context.Background(), running); err != nil {
+		t.Fatalf("deleting run: %v", err)
+	}
+	if err := m.syncActive(context.Background()); err != nil {
+		t.Fatalf("syncActive: %v", err)
+	}
+	if got := gaugeValue(t, "wf", "default"); got != 0 {
+		t.Errorf("runs_active = %v after the last run was deleted, want the series gone", got)
+	}
+}

--- a/internal/workflow/controller/run_metrics_test.go
+++ b/internal/workflow/controller/run_metrics_test.go
@@ -63,10 +63,10 @@ func histogramCount(t *testing.T, vec *prometheus.HistogramVec, labels ...string
 	return m.GetHistogram().GetSampleCount()
 }
 
-func gaugeValue(t *testing.T, namespace string) float64 {
+func gaugeValue(t *testing.T) float64 {
 	t.Helper()
 	var m dto.Metric
-	g, err := metrics.WorkflowRunsActive.GetMetricWithLabelValues("wf", namespace)
+	g, err := metrics.WorkflowRunsActive.GetMetricWithLabelValues("wf", "default")
 	if err != nil {
 		t.Fatalf("gauge: %v", err)
 	}
@@ -147,7 +147,7 @@ func TestSyncActiveCountsRunningRuns(t *testing.T) {
 	if err := m.syncActive(context.Background()); err != nil {
 		t.Fatalf("syncActive: %v", err)
 	}
-	if got := gaugeValue(t, "default"); got != 2 {
+	if got := gaugeValue(t); got != 2 {
 		t.Errorf("runs_active = %v, want 2", got)
 	}
 }
@@ -164,7 +164,7 @@ func TestSyncActiveClearsFinishedWorkflows(t *testing.T) {
 	if err := m.syncActive(context.Background()); err != nil {
 		t.Fatalf("syncActive: %v", err)
 	}
-	if got := gaugeValue(t, "default"); got != 0 {
+	if got := gaugeValue(t); got != 0 {
 		t.Errorf("runs_active = %v, want 0", got)
 	}
 }
@@ -227,7 +227,7 @@ func TestSyncActiveDropsVanishedWorkflows(t *testing.T) {
 	if err := m.syncActive(context.Background()); err != nil {
 		t.Fatalf("syncActive: %v", err)
 	}
-	if got := gaugeValue(t, "default"); got != 1 {
+	if got := gaugeValue(t); got != 1 {
 		t.Fatalf("runs_active = %v, want 1", got)
 	}
 
@@ -237,7 +237,7 @@ func TestSyncActiveDropsVanishedWorkflows(t *testing.T) {
 	if err := m.syncActive(context.Background()); err != nil {
 		t.Fatalf("syncActive: %v", err)
 	}
-	if got := gaugeValue(t, "default"); got != 0 {
+	if got := gaugeValue(t); got != 0 {
 		t.Errorf("runs_active = %v after the last run was deleted, want the series gone", got)
 	}
 }

--- a/internal/workflow/executor/executor.go
+++ b/internal/workflow/executor/executor.go
@@ -440,7 +440,6 @@ func (e *WorkflowExecutor) ExecuteWorkflow(ctx context.Context, workflow *ottofl
 		workflowRun.Status.Phase = ottoflowv1alpha1.WorkflowRunPhaseRunning
 		startNow := metav1.Now()
 		workflowRun.Status.StartTime = &startNow
-		metrics.WorkflowRunsActive.WithLabelValues(workflowName, namespace).Inc()
 		e.emitWorkflowLevelEvent(workflow, workflowRun, "WorkflowRunning", corev1.EventTypeNormal, "Workflow run started")
 	}
 
@@ -480,7 +479,7 @@ func (e *WorkflowExecutor) ExecuteWorkflow(ctx context.Context, workflow *ottofl
 				status := workflowRun.Status.StepStatuses[step.Name]
 				if status.Phase == ottoflowv1alpha1.StepPhaseFailed {
 					msg := fmt.Sprintf("Step %s failed: %s", step.Name, status.Error)
-					e.recordWorkflowFailure(workflow, workflowRun, workflowName, namespace, msg)
+					e.recordWorkflowFailure(workflow, workflowRun, msg)
 					return fmt.Errorf("workflow failed: step %s failed", step.Name)
 				}
 			}
@@ -514,7 +513,7 @@ func (e *WorkflowExecutor) ExecuteWorkflow(ctx context.Context, workflow *ottofl
 				if step.FailurePolicy == ottoflowv1alpha1.FailurePolicyContinue {
 					continue
 				}
-				e.recordWorkflowFailure(workflow, workflowRun, workflowName, namespace, fmt.Sprintf("Step %s failed: %v", stepName, err))
+				e.recordWorkflowFailure(workflow, workflowRun, fmt.Sprintf("Step %s failed: %v", stepName, err))
 				return fmt.Errorf("matchCondition evaluation failed for step %s: %w", stepName, err)
 			}
 
@@ -522,7 +521,6 @@ func (e *WorkflowExecutor) ExecuteWorkflow(ctx context.Context, workflow *ottofl
 				stepStatus.Phase = ottoflowv1alpha1.StepPhaseSkipped
 				workflowRun.Status.StepStatuses[stepName] = stepStatus
 				e.emitStepEvent(workflow, workflowRun, fmt.Sprintf("Step %q skipped (conditions not met)", stepName))
-				metrics.WorkflowStepsTotal.WithLabelValues(workflowName, namespace, stepName, "skipped").Inc()
 				e.invokeProgressCallback(workflowRun, workflow)
 				e.saveCheckpoint(ctx, workflowRun, stepName)
 				continue
@@ -585,10 +583,6 @@ func (e *WorkflowExecutor) ExecuteWorkflow(ctx context.Context, workflow *ottofl
 				stepStatus.CompletionTime = &completionTimeMeta
 				workflowRun.Status.StepStatuses[stepName] = stepStatus
 				e.emitStepEventWarning(workflow, workflowRun, fmt.Sprintf("Step %q failed: %s", stepName, err.Error()))
-				metrics.WorkflowStepsTotal.WithLabelValues(workflowName, namespace, stepName, "failed").Inc()
-				if stepStatus.StartTime != nil {
-					metrics.WorkflowStepDurationSeconds.WithLabelValues(workflowName, namespace, stepName).Observe(completionTime.Sub(stepStatus.StartTime.Time).Seconds())
-				}
 				e.invokeProgressCallback(workflowRun, workflow)
 
 				if step.FailurePolicy == ottoflowv1alpha1.FailurePolicyContinue {
@@ -596,7 +590,7 @@ func (e *WorkflowExecutor) ExecuteWorkflow(ctx context.Context, workflow *ottofl
 					continue
 				}
 
-				e.recordWorkflowFailure(workflow, workflowRun, workflowName, namespace, fmt.Sprintf("Step %s failed: %v", stepName, err))
+				e.recordWorkflowFailure(workflow, workflowRun, fmt.Sprintf("Step %s failed: %v", stepName, err))
 				return err
 			}
 			// Mark step as succeeded
@@ -613,10 +607,6 @@ func (e *WorkflowExecutor) ExecuteWorkflow(ctx context.Context, workflow *ottofl
 			}
 			workflowRun.Status.StepStatuses[stepName] = stepStatus
 			e.emitStepEvent(workflow, workflowRun, fmt.Sprintf("Step %q succeeded", stepName))
-			metrics.WorkflowStepsTotal.WithLabelValues(workflowName, namespace, stepName, "succeeded").Inc()
-			if stepStatus.StartTime != nil {
-				metrics.WorkflowStepDurationSeconds.WithLabelValues(workflowName, namespace, stepName).Observe(completionTime.Sub(stepStatus.StartTime.Time).Seconds())
-			}
 			e.invokeProgressCallback(workflowRun, workflow)
 			e.contextManager.RecordStepCompletion(stepName)
 			e.saveCheckpoint(ctx, workflowRun, stepName)
@@ -678,16 +668,11 @@ func (e *WorkflowExecutor) evaluateWorkflowVariables(ctx context.Context, workfl
 func (e *WorkflowExecutor) recordWorkflowFailure(
 	workflow *ottoflowv1alpha1.Workflow,
 	workflowRun *ottoflowv1alpha1.WorkflowRun,
-	workflowName, namespace, message string,
+	message string,
 ) {
 	workflowRun.Status.Phase = ottoflowv1alpha1.WorkflowRunPhaseFailed
 	workflowRun.Status.Message = message
 	e.emitWorkflowLevelEvent(workflow, workflowRun, "WorkflowFailed", corev1.EventTypeWarning, message)
-	metrics.WorkflowRunsActive.WithLabelValues(workflowName, namespace).Dec()
-	metrics.WorkflowRunsTotal.WithLabelValues(workflowName, namespace, "failed").Inc()
-	if workflowRun.Status.StartTime != nil {
-		metrics.WorkflowRunDurationSeconds.WithLabelValues(workflowName, namespace).Observe(time.Since(workflowRun.Status.StartTime.Time).Seconds())
-	}
 }
 
 func (e *WorkflowExecutor) recordWorkflowSuccess(
@@ -703,11 +688,6 @@ func (e *WorkflowExecutor) recordWorkflowSuccess(
 
 	if err := e.evaluateWorkflowOutputs(ctx, workflow, workflowRun, workflowName, namespace); err != nil {
 		fmt.Printf("Warning: failed to evaluate workflow outputs: %v\n", err)
-	}
-	metrics.WorkflowRunsActive.WithLabelValues(workflowName, namespace).Dec()
-	metrics.WorkflowRunsTotal.WithLabelValues(workflowName, namespace, "succeeded").Inc()
-	if workflowRun.Status.StartTime != nil {
-		metrics.WorkflowRunDurationSeconds.WithLabelValues(workflowName, namespace).Observe(now.Time.Sub(workflowRun.Status.StartTime.Time).Seconds())
 	}
 	e.invokeProgressCallback(workflowRun, workflow)
 }


### PR DESCRIPTION
Closes #9. Follows #50, which fixed the chart and the registry.

The five `ottoflow_workflow_*` metrics were incremented by the executor, which runs in the runner Job — no HTTP, then exits. They have never been scrapeable.

The issue asks whether they need a push path or should move to the controller. Neither: WorkflowRun status already carries what all five need. `StepStatuses` has each step's phase, start and completion time; the run has its own phase and times. The runner writes status and the controller watches it, so the data already crosses the process boundary.

A new leader-elected runnable watches WorkflowRun updates and records on the transition into a terminal phase.

- Updates only. A restart replays the cache as adds, and counting those would re-count runs already counted.
- Leader-elected, because counters are per-process — every replica recording every run would multiply them.
- `runs_active` is recomputed from a list every 30s instead of being incremented and decremented. A gauge tracked by deltas drifts past any missed event and stays wrong.

The executor's increments are removed. Two writers where one can never be observed is the same silent no-op this issue is about.

## Verified

Controller against kind, run driven through Running then Succeeded with one finished step:

```
ottoflow_workflow_runs_total{phase="succeeded",workflow="wf"}      1
ottoflow_workflow_run_duration_seconds_sum{workflow="wf"}          12
ottoflow_workflow_steps_total{phase="succeeded",step="summarize"}  1
ottoflow_workflow_step_duration_seconds_sum{step="summarize"}      3
ottoflow_workflow_runs_active{workflow="wf"}                       1
```

Durations match the patched timestamps (12s run, 3s step). Patching the finished run again leaves `runs_total` at 1.

Unit tests cover the transition, the repeat, step results including skipped, and the gauge resync clearing a workflow whose runs have all finished.

`make build`, `make verify-codegen`, `go test`, `helm lint` pass.

## One gap worth naming

A transition that happens while the controller is down is not counted — the run is already terminal when the cache replays it as an add, and that add is deliberately ignored. Counting adds instead would double count every terminal run on every restart, which is worse. If undercounting matters more than double counting for your use, say so and I will invert it.
