### PR TITLE
fix: give the e2e suite a timeout with headroom

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,10 +162,10 @@ test-e2e: ## Run e2e tests (expects a kube cluster; use test-e2e-kind to create 
 	# try to reach a cluster. Dropping this tag makes the suite compile to zero tests and
 	# pass vacuously, so keep it in step with the //go:build lines in test/e2e.
 	# -timeout, because the Go default is 10m and this suite runs for ~9m30s:
-	# waits on cron fires give it no headroom. Kept under the workflow's
-	# timeout-minutes so a real hang panics with a goroutine dump instead of
-	# the runner killing the job with no output.
-	go test -tags e2e ./test/e2e/ -v -ginkgo.v -count=1 -timeout 25m
+	# waits on cron fires give it no headroom. Well under the workflow's
+	# timeout-minutes, which also has to cover setup, so a real hang panics
+	# with a goroutine dump instead of the runner killing the job silently.
+	go test -tags e2e ./test/e2e/ -v -ginkgo.v -count=1 -timeout 20m
 
 KIND_CLUSTER ?= kind
 .PHONY: test-e2e-kind

--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,11 @@ test-e2e: ## Run e2e tests (expects a kube cluster; use test-e2e-kind to create 
 	# The e2e files are behind the `e2e` build tag so that a plain `go test ./...` does not
 	# try to reach a cluster. Dropping this tag makes the suite compile to zero tests and
 	# pass vacuously, so keep it in step with the //go:build lines in test/e2e.
-	go test -tags e2e ./test/e2e/ -v -ginkgo.v -count=1
+	# -timeout, because the Go default is 10m and this suite runs for ~9m30s:
+	# waits on cron fires give it no headroom. Kept under the workflow's
+	# timeout-minutes so a real hang panics with a goroutine dump instead of
+	# the runner killing the job with no output.
+	go test -tags e2e ./test/e2e/ -v -ginkgo.v -count=1 -timeout 25m
 
 KIND_CLUSTER ?= kind
 .PHONY: test-e2e-kind


### PR DESCRIPTION
Fixes the e2e failure tracked in #62, which is currently blocking every PR through `e2e-gate`.

`make test-e2e` passes no `-timeout`, so the suite runs under Go's 10m default. Duration of the e2e step on the last three passing runs on `main`:

| Run | Commit | e2e step |
| --- | --- | --- |
| 32895703596 | #47 | 562s |
| 33000737125 | #49 | 565s |
| 33041633440 | #50 | 566s |

Against a 600s default that is ~34 seconds of headroom. The run at `830b7048` spent it and panicked at exactly `10m0s` while waiting past a cron fire in the cron-delete spec.

`#61` did not break anything — it changed a model name string, its test, and two samples. It was just the commit that happened to tip the suite over.

The job already allows `timeout-minutes: 30`, which also has to cover setup — measured at 70s on the failing run (kind is 41s of it). This sets `-timeout 20m`: twice what a ~9m30s suite needs, and it leaves about 9m for setup, so a genuine hang still panics with a goroutine dump rather than the runner killing the job with no output.

Not addressed here: the suite takes ~9m30s and the cron specs are most of it. Worth its own issue if you want it faster rather than just not-failing.

## Ordering

`e2e-gate` blocks this PR too, since #62 is open. Closing #62 or merging this past the gate will let the next e2e run on `main` go green, which auto-closes the issue and unblocks the rest.
