### PR TITLE
fix: round-trip Kubernetes CEL library types through step outputs (+ pod-triage output guard)

### DIFF
--- a/internal/workflow/executor/cel_unstructured_adapter.go
+++ b/internal/workflow/executor/cel_unstructured_adapter.go
@@ -8,19 +8,31 @@ that can be found in the LICENSE.md file.
 package executor
 
 import (
+	"net/netip"
+
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-// unstructuredAdapter unboxes typed Kubernetes objects into their plain
-// map form before delegating to the environment's composed adapter.
-// cel-go 0.31 removed the arbitrary-struct wrapping fallback from the
-// NativeTypes provider, so a bound *unstructured.Unstructured no longer
-// auto-converts and yields "unsupported conversion to ref.Val" instead.
-// Known limit: a typed Unstructured nested inside a container that is
-// converted wholesale (e.g. []any{u1,u2}) is not unboxed by this adapter;
-// no current code path binds such a shape.
+// unstructuredAdapter closes two gaps cel-go 0.31 left in native->ref.Val
+// conversion, then delegates to the base adapter:
+//
+//   - unboxes *unstructured.Unstructured to its plain map (0.31 dropped the
+//     struct-wrapping fallback, so the base adapter errors on it);
+//   - stringifies the Go natives cidr()/ip()/quantity() leave behind
+//     (netip.Prefix, netip.Addr, *resource.Quantity), which the base adapter
+//     can't convert back when a step re-reads them as an output.
+//
+// Only these three are stringified: for each, String() equals its JSON
+// encoding, so an in-memory read matches the value reloaded after the step
+// context is checkpointed. Do NOT add a type whose String() differs from its
+// JSON form (e.g. url() -> *url.URL, a JSON struct) -- it would read as a
+// string before a checkpoint and a map after.
+//
+// Known limit: a typed Unstructured nested in a wholesale-converted container
+// (e.g. []any{u1,u2}) is not unboxed; no code path binds that shape today.
 type unstructuredAdapter struct {
 	base types.Adapter
 }
@@ -34,6 +46,17 @@ func (a unstructuredAdapter) NativeToValue(value any) ref.Val {
 			return types.NullValue // explicit: a typed nil ptr is NOT a nil interface
 		}
 		return a.base.NativeToValue(v.Object)
+	case netip.Prefix:
+		return types.String(v.String())
+	case netip.Addr:
+		return types.String(v.String())
+	case *resource.Quantity:
+		if v == nil {
+			return types.NullValue
+		}
+		return types.String(v.String())
+	case resource.Quantity:
+		return types.String(v.String())
 	default:
 		return a.base.NativeToValue(value)
 	}

--- a/internal/workflow/executor/cel_unstructured_adapter_test.go
+++ b/internal/workflow/executor/cel_unstructured_adapter_test.go
@@ -8,11 +8,13 @@ that can be found in the LICENSE.md file.
 package executor
 
 import (
+	"net/netip"
 	"testing"
 
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/common/types/traits"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -76,6 +78,44 @@ func TestUnstructuredAdapter(t *testing.T) {
 			check: func(t *testing.T, result ref.Val) {
 				if _, ok := result.(traits.Mapper); !ok {
 					t.Fatalf("expected traits.Mapper, got %T", result)
+				}
+			},
+		},
+		// cidr()/ip()/quantity() outputs are stored as these natives; the adapter
+		// must render each as its canonical string (== its JSON form), not error.
+		{
+			name:  "netip.Prefix (cidr masked output) stringifies",
+			input: netip.MustParsePrefix("192.168.0.0/16"),
+			check: func(t *testing.T, result ref.Val) {
+				if result.Equal(types.String("192.168.0.0/16")) != types.True {
+					t.Fatalf("expected %q, got %v (%T)", "192.168.0.0/16", result, result)
+				}
+			},
+		},
+		{
+			name:  "netip.Addr (ip output) stringifies",
+			input: netip.MustParseAddr("10.0.0.5"),
+			check: func(t *testing.T, result ref.Val) {
+				if result.Equal(types.String("10.0.0.5")) != types.True {
+					t.Fatalf("expected %q, got %v (%T)", "10.0.0.5", result, result)
+				}
+			},
+		},
+		{
+			name:  "*resource.Quantity stringifies",
+			input: resource.NewQuantity(2*1024*1024*1024, resource.BinarySI),
+			check: func(t *testing.T, result ref.Val) {
+				if result.Equal(types.String("2Gi")) != types.True {
+					t.Fatalf("expected %q, got %v (%T)", "2Gi", result, result)
+				}
+			},
+		},
+		{
+			name:  "typed nil *resource.Quantity returns NullValue, does not panic on String()",
+			input: (*resource.Quantity)(nil),
+			check: func(t *testing.T, result ref.Val) {
+				if result != types.NullValue {
+					t.Fatalf("expected types.NullValue, got %v (%T)", result, result)
 				}
 			},
 		},

--- a/samples/workflows/production/pod-triage.yaml
+++ b/samples/workflows/production/pod-triage.yaml
@@ -127,4 +127,6 @@ spec:
 
   outputs:
     - name: triageSummary
-      expression: variables.summary
+      # publishTriage runs only when collectPods found pods, so variables.summary
+      # is absent for an empty namespace; guard it so the output resolves cleanly.
+      expression: 'has(variables.summary) ? variables.summary : "No pods found to triage."'


### PR DESCRIPTION
## What & why

Two fixes surfaced while validating the sample workflows against a local kind cluster.

> This branch originally also carried the Anthropic trailing-usage-chunk streaming fix; that has been dropped because it duplicates #51 (filed first) — deferring the streaming fix to that PR.

### 1. `fix(executor)` — Kubernetes CEL library types round-trip through step outputs

Any workflow that outputs the raw result of `cidr()`, `ip()`, or `quantity()` failed with:
```
unsupported conversion to ref.Val: (netip.Prefix)192.168.0.0/16
```
These results are stored as their Go natives (`netip.Prefix`, `netip.Addr`, `*resource.Quantity`) when a step records them as an output; cel-go's base adapter has no reverse conversion, so re-reading the output crashed.

Fix, in the single native→CEL choke point (`unstructuredAdapter.NativeToValue`): render these three types as their `String()`. That value equals their JSON encoding, so the in-memory value matches the value reloaded after the step context is checkpointed and JSON round-tripped. Types whose `String()` differs from their JSON form (e.g. `url()` → `*url.URL`, a struct) are **deliberately excluded** — stringifying them would read as a string before a checkpoint and a map after. Tests cover cidr/ip/quantity plus a typed-nil guard.

### 2. `fix(samples)` — pod-triage `triageSummary` guarded for the no-pods case

`publishTriage` runs only when `collectPods` found pods, so `variables.summary` is absent when the queried namespace has no pods and the workflow-level `triageSummary` output emitted a CEL evaluation warning. Guarded with `has()`.

## Verification
- `go test ./internal/workflow/executor/...` — all pass, including the new adapter tests.
- End-to-end on a kind cluster: `kubernetes-cel-libraries` runs clean (cidr/ip/quantity outputs); pod-triage's `triageSummary` resolves both when pods exist (real verdict) and when the queried namespace is empty (guarded message, no warning).

## Related / follow-ups
- **Anthropic streaming ("no candidates")** — handled by #51 (filed first); not included here.
- **`resource.GetLogs` in local CLI execution** — tracked in #66.
- **`agent-step` sample extraction fragility** — tracked in #67.
- Both samples also sit under the umbrella sample-quality issue #11.
