### PR TITLE
fix: authorize the runner ServiceAccount override at admission

### DIFF
--- a/charts/ottoflow/templates/clusterrole.yaml
+++ b/charts/ottoflow/templates/clusterrole.yaml
@@ -25,6 +25,15 @@ metadata:
     rbac.ottoflow.io/aggregate-to-controller: "true"
     rbac.ottoflow.io/aggregate-instance: {{ include "ottoflow.fullname" . }}
 rules:
+  # SubjectAccessReview - the WorkflowRun admission webhook asks whether the
+  # submitter may run as the ServiceAccount a run names, and the MCP server
+  # asks whether a caller may invoke workflows.
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
   # OttoFlow CRDs - read-only for agents, mcpservers, steptemplates
   - apiGroups:
       - ottoflow.nirmata.io

--- a/charts/ottoflow/templates/mcp-auth-clusterrole.yaml
+++ b/charts/ottoflow/templates/mcp-auth-clusterrole.yaml
@@ -1,9 +1,9 @@
 {{- if and .Values.controller.mcp .Values.controller.mcp.enabled .Values.rbac.create }}
-# MCP auth ClusterRole - lets the controller authenticate and authorize MCP
-# callers. TokenReview turns the caller's bearer token into an identity;
-# SubjectAccessReview asks whether that identity may get the mcp-caller
-# ConfigMap. Aggregated into the controller role only while the MCP server is
-# enabled, so a deployment that does not serve MCP never holds these verbs.
+# MCP auth ClusterRole - lets the controller authenticate MCP callers.
+# TokenReview turns the caller's bearer token into an identity. Aggregated into
+# the controller role only while the MCP server is enabled, so a deployment that
+# does not serve MCP never holds this verb. SubjectAccessReview is in the core
+# role, since the admission webhook needs it too.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -18,12 +18,6 @@ rules:
       - authentication.k8s.io
     resources:
       - tokenreviews
-    verbs:
-      - create
-  - apiGroups:
-      - authorization.k8s.io
-    resources:
-      - subjectaccessreviews
     verbs:
       - create
 {{- end }}

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -431,10 +431,14 @@ func main() {
 	hookPathAgent := "/validate-ottoflow-nirmata-io-v1alpha1-agent"
 	hookPathMCPServer := "/validate-ottoflow-nirmata-io-v1alpha1-mcpserver"
 	mgr.GetWebhookServer().Register(hookPathWorkflow, &ctrlwebhook.Admission{
-		Handler: admission.WithValidator(scheme, &ottowebhook.WorkflowValidator{Client: mgr.GetClient()}),
+		Handler: admission.WithValidator(scheme, &ottowebhook.WorkflowValidator{
+			Client:     mgr.GetClient(),
+			Authorizer: clientset.AuthorizationV1().SubjectAccessReviews(),
+		}),
 	})
 	mgr.GetWebhookServer().Register(hookPathWorkflowRun, &ctrlwebhook.Admission{
 		Handler: admission.WithValidator(scheme, &ottowebhook.WorkflowRunValidator{
+			Client:     mgr.GetClient(),
 			Authorizer: clientset.AuthorizationV1().SubjectAccessReviews(),
 		}),
 	})

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -434,7 +434,9 @@ func main() {
 		Handler: admission.WithValidator(scheme, &ottowebhook.WorkflowValidator{Client: mgr.GetClient()}),
 	})
 	mgr.GetWebhookServer().Register(hookPathWorkflowRun, &ctrlwebhook.Admission{
-		Handler: admission.WithValidator(scheme, &ottowebhook.WorkflowRunValidator{}),
+		Handler: admission.WithValidator(scheme, &ottowebhook.WorkflowRunValidator{
+			Authorizer: clientset.AuthorizationV1().SubjectAccessReviews(),
+		}),
 	})
 	mgr.GetWebhookServer().Register(hookPathAgent, &ctrlwebhook.Admission{
 		Handler: admission.WithValidator(scheme, &ottowebhook.AgentValidator{}),

--- a/docs/user/reference/api/workflowrun.md
+++ b/docs/user/reference/api/workflowrun.md
@@ -158,5 +158,10 @@ rules:
 
 then bind it to the users or ServiceAccounts that submit those runs.
 
+A Workflow can declare the account instead, under `spec.execution.job`, and the
+same check runs when the Workflow is admitted — that is where the account is
+chosen. Runs created from it, including cron runs the scheduler creates, inherit
+the account and are not reviewed again.
+
 Runs that set no `serviceAccountName` are unaffected: they get the dedicated
 least-privilege runner account, and no review is issued.

--- a/docs/user/reference/api/workflowrun.md
+++ b/docs/user/reference/api/workflowrun.md
@@ -65,7 +65,7 @@ Exactly one cluster source should be set when `clusterRef` is present.
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `image` | string | No | Override the runner image. |
-| `serviceAccountName` | string | No | Service account for the runner Job. |
+| `serviceAccountName` | string | No | Service account for the runner Job. Requires authorization — see [Running as another ServiceAccount](#running-as-another-serviceaccount). |
 | `env` | []EnvVar | No | Extra environment variables for the runner container. For credentials (e.g. Nirmata LLM), use `valueFrom.secretKeyRef` to reference a Secret; do not use plain `value`. |
 | `resources` | ResourceRequirements | No | Container resource requests and limits. |
 | `volumes` | []Volume | No | Extra pod volumes, including CSI/projected/Secret volumes. |
@@ -126,3 +126,37 @@ Exactly one cluster source should be set when `clusterRef` is present.
 | `message` | string | Additional runner status information. |
 | `startTime` | string (date-time) | When runner Job execution started. |
 | `completionTime` | string (date-time) | When runner Job execution completed. |
+
+## Running as another ServiceAccount
+
+The runner Job is launched with the token of the ServiceAccount it runs as, so
+`spec.execution.job.serviceAccountName` hands the workflow that account's
+permissions. Admission therefore checks that whoever submitted the WorkflowRun
+is allowed to run as it, with a `SubjectAccessReview` for `use` on that
+ServiceAccount. A run naming an account the submitter is not allowed to use is
+rejected:
+
+```text
+WorkflowRun "nightly": "system:serviceaccount:team-a:submitter" may not use
+serviceaccount "privileged-sa" in namespace "team-a"
+```
+
+Grant it by naming the accounts a subject may borrow:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: use-build-runner
+  namespace: team-a
+rules:
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    resourceNames: ["build-runner"]
+    verbs: ["use"]
+```
+
+then bind it to the users or ServiceAccounts that submit those runs.
+
+Runs that set no `serviceAccountName` are unaffected: they get the dedicated
+least-privilege runner account, and no review is issued.

--- a/internal/webhook/runner_serviceaccount.go
+++ b/internal/webhook/runner_serviceaccount.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2026 Nirmata, Inc.
+
+Use of this source code is governed by the Business Source License 1.1
+that can be found in the LICENSE.md file.
+*/
+
+package webhook
+
+import (
+	"context"
+	"fmt"
+
+	authorizationv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	ottoflowv1alpha1 "github.com/nirmata/ottoflow/api/v1alpha1"
+)
+
+// UseVerb is the verb a subject needs on a ServiceAccount to run a workflow as
+// it. Grant it with a Role naming the ServiceAccounts a subject may borrow:
+//
+//	rules:
+//	- apiGroups: [""]
+//	  resources: ["serviceaccounts"]
+//	  resourceNames: ["build-runner"]
+//	  verbs: ["use"]
+const UseVerb = "use"
+
+// SubjectAccessReviewer creates SubjectAccessReviews.
+// kubernetes.Interface's AuthorizationV1().SubjectAccessReviews() satisfies it.
+type SubjectAccessReviewer interface {
+	Create(ctx context.Context, sar *authorizationv1.SubjectAccessReview, opts metav1.CreateOptions) (*authorizationv1.SubjectAccessReview, error)
+}
+
+// authorizeRunnerServiceAccount checks that whoever submitted this WorkflowRun
+// may run workloads as the ServiceAccount it names.
+//
+// Without it, spec.execution.job.serviceAccountName is an escalation: the
+// runner Job is launched with that ServiceAccount's token, so anyone who can
+// create a WorkflowRun can name a privileged ServiceAccount and get its
+// credentials, which is what scoping the runner to its own least-privilege
+// role set out to prevent.
+func (v *WorkflowRunValidator) authorizeRunnerServiceAccount(ctx context.Context, run *ottoflowv1alpha1.WorkflowRun) error {
+	serviceAccount := runnerServiceAccountName(run)
+	if serviceAccount == "" {
+		return nil
+	}
+
+	if v.Authorizer == nil {
+		return fmt.Errorf("WorkflowRun %q sets spec.execution.job.serviceAccountName but the validator cannot authorize it", run.Name)
+	}
+
+	request, err := admission.RequestFromContext(ctx)
+	if err != nil {
+		return fmt.Errorf("WorkflowRun %q sets spec.execution.job.serviceAccountName but the request carries no user to authorize: %w", run.Name, err)
+	}
+
+	extra := map[string]authorizationv1.ExtraValue{}
+	for key, values := range request.UserInfo.Extra {
+		extra[key] = authorizationv1.ExtraValue(values)
+	}
+
+	review, err := v.Authorizer.Create(ctx, &authorizationv1.SubjectAccessReview{
+		Spec: authorizationv1.SubjectAccessReviewSpec{
+			User:   request.UserInfo.Username,
+			UID:    request.UserInfo.UID,
+			Groups: request.UserInfo.Groups,
+			Extra:  extra,
+			ResourceAttributes: &authorizationv1.ResourceAttributes{
+				Namespace: run.Namespace,
+				Verb:      UseVerb,
+				Resource:  "serviceaccounts",
+				Name:      serviceAccount,
+			},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("WorkflowRun %q: checking whether %q may use serviceaccount %q: %w",
+			run.Name, request.UserInfo.Username, serviceAccount, err)
+	}
+	if !review.Status.Allowed {
+		return fmt.Errorf("WorkflowRun %q: %q may not use serviceaccount %q in namespace %q%s",
+			run.Name, request.UserInfo.Username, serviceAccount, run.Namespace, reviewReason(review))
+	}
+	return nil
+}
+
+func runnerServiceAccountName(run *ottoflowv1alpha1.WorkflowRun) string {
+	if run.Spec.Execution == nil || run.Spec.Execution.Job == nil {
+		return ""
+	}
+	return run.Spec.Execution.Job.ServiceAccountName
+}
+
+func reviewReason(review *authorizationv1.SubjectAccessReview) string {
+	if review.Status.Reason == "" {
+		return ""
+	}
+	return ": " + review.Status.Reason
+}

--- a/internal/webhook/runner_serviceaccount.go
+++ b/internal/webhook/runner_serviceaccount.go
@@ -13,6 +13,7 @@ import (
 
 	authorizationv1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	ottoflowv1alpha1 "github.com/nirmata/ottoflow/api/v1alpha1"
@@ -43,18 +44,65 @@ type SubjectAccessReviewer interface {
 // credentials, which is what scoping the runner to its own least-privilege
 // role set out to prevent.
 func (v *WorkflowRunValidator) authorizeRunnerServiceAccount(ctx context.Context, run *ottoflowv1alpha1.WorkflowRun) error {
-	serviceAccount := runnerServiceAccountName(run)
+	serviceAccount := runnerServiceAccountName(run.Spec.Execution)
 	if serviceAccount == "" {
 		return nil
 	}
+	if v.inheritedFromWorkflow(ctx, run, serviceAccount) {
+		return nil
+	}
+	return authorizeUse(ctx, v.Authorizer, run.Namespace, serviceAccount, fmt.Sprintf("WorkflowRun %q", run.Name))
+}
 
-	if v.Authorizer == nil {
-		return fmt.Errorf("WorkflowRun %q sets spec.execution.job.serviceAccountName but the validator cannot authorize it", run.Name)
+// inheritedFromWorkflow reports whether this run is using the ServiceAccount
+// its Workflow declares rather than choosing one.
+//
+// The scheduler copies spec.execution from the Workflow into each run it
+// creates, and creates it as the controller, so reviewing the submitter would
+// ask whether the controller may use the account and reject every cron run.
+// The declaration was already authorized when the Workflow was admitted, and
+// every run of that Workflow uses that account anyway, so there is nothing
+// left to decide here.
+//
+// Same namespace only: the account is used in the run's namespace, and a
+// Workflow elsewhere was authorized against its own.
+func (v *WorkflowRunValidator) inheritedFromWorkflow(ctx context.Context, run *ottoflowv1alpha1.WorkflowRun, serviceAccount string) bool {
+	if v.Client == nil {
+		return false
+	}
+	if ns := run.Spec.WorkflowRef.Namespace; ns != "" && ns != run.Namespace {
+		return false
+	}
+
+	var workflow ottoflowv1alpha1.Workflow
+	key := client.ObjectKey{Namespace: run.Namespace, Name: run.Spec.WorkflowRef.Name}
+	if err := v.Client.Get(ctx, key, &workflow); err != nil {
+		return false
+	}
+	return runnerServiceAccountName(workflow.Spec.Execution) == serviceAccount
+}
+
+// authorizeWorkflowServiceAccount checks the Workflow author may run as the
+// ServiceAccount the Workflow declares. This is where the account is chosen;
+// runs created from the Workflow inherit it.
+func (v *WorkflowValidator) authorizeWorkflowServiceAccount(ctx context.Context, workflow *ottoflowv1alpha1.Workflow) error {
+	serviceAccount := runnerServiceAccountName(workflow.Spec.Execution)
+	if serviceAccount == "" {
+		return nil
+	}
+	return authorizeUse(ctx, v.Authorizer, workflow.Namespace, serviceAccount, fmt.Sprintf("Workflow %q", workflow.Name))
+}
+
+// authorizeUse asks whether the identity behind this admission request may run
+// workloads as serviceAccount in namespace.
+func authorizeUse(ctx context.Context, authorizer SubjectAccessReviewer, namespace, serviceAccount, subject string) error {
+	if authorizer == nil {
+		return fmt.Errorf("%s sets spec.execution.job.serviceAccountName but the validator cannot authorize it", subject)
 	}
 
 	request, err := admission.RequestFromContext(ctx)
 	if err != nil {
-		return fmt.Errorf("WorkflowRun %q sets spec.execution.job.serviceAccountName but the request carries no user to authorize: %w", run.Name, err)
+		return fmt.Errorf("%s sets spec.execution.job.serviceAccountName but the request carries no user to authorize: %w", subject, err)
 	}
 
 	extra := map[string]authorizationv1.ExtraValue{}
@@ -62,14 +110,14 @@ func (v *WorkflowRunValidator) authorizeRunnerServiceAccount(ctx context.Context
 		extra[key] = authorizationv1.ExtraValue(values)
 	}
 
-	review, err := v.Authorizer.Create(ctx, &authorizationv1.SubjectAccessReview{
+	review, err := authorizer.Create(ctx, &authorizationv1.SubjectAccessReview{
 		Spec: authorizationv1.SubjectAccessReviewSpec{
 			User:   request.UserInfo.Username,
 			UID:    request.UserInfo.UID,
 			Groups: request.UserInfo.Groups,
 			Extra:  extra,
 			ResourceAttributes: &authorizationv1.ResourceAttributes{
-				Namespace: run.Namespace,
+				Namespace: namespace,
 				Verb:      UseVerb,
 				Resource:  "serviceaccounts",
 				Name:      serviceAccount,
@@ -77,21 +125,21 @@ func (v *WorkflowRunValidator) authorizeRunnerServiceAccount(ctx context.Context
 		},
 	}, metav1.CreateOptions{})
 	if err != nil {
-		return fmt.Errorf("WorkflowRun %q: checking whether %q may use serviceaccount %q: %w",
-			run.Name, request.UserInfo.Username, serviceAccount, err)
+		return fmt.Errorf("%s: checking whether %q may use serviceaccount %q: %w",
+			subject, request.UserInfo.Username, serviceAccount, err)
 	}
 	if !review.Status.Allowed {
-		return fmt.Errorf("WorkflowRun %q: %q may not use serviceaccount %q in namespace %q%s",
-			run.Name, request.UserInfo.Username, serviceAccount, run.Namespace, reviewReason(review))
+		return fmt.Errorf("%s: %q may not use serviceaccount %q in namespace %q%s",
+			subject, request.UserInfo.Username, serviceAccount, namespace, reviewReason(review))
 	}
 	return nil
 }
 
-func runnerServiceAccountName(run *ottoflowv1alpha1.WorkflowRun) string {
-	if run.Spec.Execution == nil || run.Spec.Execution.Job == nil {
+func runnerServiceAccountName(execution *ottoflowv1alpha1.WorkflowRunExecutionSpec) string {
+	if execution == nil || execution.Job == nil {
 		return ""
 	}
-	return run.Spec.Execution.Job.ServiceAccountName
+	return execution.Job.ServiceAccountName
 }
 
 func reviewReason(review *authorizationv1.SubjectAccessReview) string {

--- a/internal/webhook/runner_serviceaccount_test.go
+++ b/internal/webhook/runner_serviceaccount_test.go
@@ -17,6 +17,9 @@ import (
 	authenticationv1 "k8s.io/api/authentication/v1"
 	authorizationv1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	ottoflowv1alpha1 "github.com/nirmata/ottoflow/api/v1alpha1"
@@ -178,5 +181,112 @@ func TestRunnerServiceAccountFailsClosed(t *testing.T) {
 				t.Errorf("error = %q, want it to contain %q", err, tc.want)
 			}
 		})
+	}
+}
+
+func workflowWithServiceAccount(namespace, serviceAccount string) *ottoflowv1alpha1.Workflow {
+	wf := &ottoflowv1alpha1.Workflow{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "wf"},
+		Spec: ottoflowv1alpha1.WorkflowSpec{
+			Steps: []ottoflowv1alpha1.Step{{Name: "s1"}},
+		},
+	}
+	if serviceAccount != "" {
+		wf.Spec.Execution = &ottoflowv1alpha1.WorkflowRunExecutionSpec{
+			Job: &ottoflowv1alpha1.WorkflowRunJobSpec{ServiceAccountName: serviceAccount},
+		}
+	}
+	return wf
+}
+
+func clientWith(t *testing.T, objects ...client.Object) client.Client {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := ottoflowv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("scheme: %v", err)
+	}
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+}
+
+// The scheduler copies spec.execution from the Workflow into every cron run and
+// creates it as the controller, so reviewing the submitter would ask whether
+// the controller may use the account and reject every such run. The
+// declaration was authorized when the Workflow was admitted.
+func TestInheritedServiceAccountIsNotReviewedAgain(t *testing.T) {
+	reviewer := &fakeReviewer{allowed: false}
+	v := &WorkflowRunValidator{
+		Authorizer: reviewer,
+		Client:     clientWith(t, workflowWithServiceAccount("team-a", "build-runner")),
+	}
+
+	if _, err := v.ValidateCreate(requestContext(), runWithServiceAccount("build-runner")); err != nil {
+		t.Fatalf("run inheriting its Workflow's ServiceAccount rejected: %v", err)
+	}
+	if reviewer.got != nil {
+		t.Error("a review was issued for an inherited ServiceAccount")
+	}
+}
+
+// Inheriting is only a pass for the account the Workflow actually declares.
+func TestRunChoosingADifferentServiceAccountIsReviewed(t *testing.T) {
+	reviewer := &fakeReviewer{allowed: false}
+	v := &WorkflowRunValidator{
+		Authorizer: reviewer,
+		Client:     clientWith(t, workflowWithServiceAccount("team-a", "build-runner")),
+	}
+
+	if _, err := v.ValidateCreate(requestContext(), runWithServiceAccount("privileged-sa")); err == nil {
+		t.Fatal("a run naming an account its Workflow does not declare was admitted")
+	}
+	if reviewer.got == nil {
+		t.Error("no review was issued")
+	}
+}
+
+// The account is used in the run's namespace, so a Workflow elsewhere — which
+// was authorized against its own namespace — cannot vouch for it.
+func TestInheritanceDoesNotCrossNamespaces(t *testing.T) {
+	reviewer := &fakeReviewer{allowed: false}
+	run := runWithServiceAccount("build-runner")
+	run.Spec.WorkflowRef.Namespace = "team-b"
+	v := &WorkflowRunValidator{
+		Authorizer: reviewer,
+		Client:     clientWith(t, workflowWithServiceAccount("team-b", "build-runner")),
+	}
+
+	if _, err := v.ValidateCreate(requestContext(), run); err == nil {
+		t.Fatal("a run was admitted on the say-so of a Workflow in another namespace")
+	}
+}
+
+// The Workflow is where the account is chosen, so that is where its author is
+// authorized.
+func TestWorkflowServiceAccountRequiresAuthorization(t *testing.T) {
+	denied := &WorkflowValidator{Authorizer: &fakeReviewer{allowed: false, reason: "no binding"}}
+	_, err := denied.ValidateCreate(requestContext(), workflowWithServiceAccount("team-a", "privileged-sa"))
+	if err == nil {
+		t.Fatal("a Workflow declaring an unauthorized ServiceAccount was admitted")
+	}
+	for _, want := range []string{"Workflow", "alice", "privileged-sa", "team-a"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not name %q", err, want)
+		}
+	}
+
+	allowed := &WorkflowValidator{Authorizer: &fakeReviewer{allowed: true}}
+	if _, err := allowed.ValidateCreate(requestContext(), workflowWithServiceAccount("team-a", "build-runner")); err != nil {
+		t.Fatalf("authorized Workflow rejected: %v", err)
+	}
+}
+
+func TestWorkflowWithoutServiceAccountIsNotReviewed(t *testing.T) {
+	reviewer := &fakeReviewer{allowed: false}
+	v := &WorkflowValidator{Authorizer: reviewer}
+
+	if _, err := v.ValidateCreate(requestContext(), workflowWithServiceAccount("team-a", "")); err != nil {
+		t.Fatalf("Workflow without a ServiceAccount rejected: %v", err)
+	}
+	if reviewer.got != nil {
+		t.Error("a review was issued for a Workflow that declares no ServiceAccount")
 	}
 }

--- a/internal/webhook/runner_serviceaccount_test.go
+++ b/internal/webhook/runner_serviceaccount_test.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2026 Nirmata, Inc.
+
+Use of this source code is governed by the Business Source License 1.1
+that can be found in the LICENSE.md file.
+*/
+
+package webhook
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	ottoflowv1alpha1 "github.com/nirmata/ottoflow/api/v1alpha1"
+)
+
+// fakeReviewer records the SubjectAccessReview it was asked for and answers
+// with a fixed verdict.
+type fakeReviewer struct {
+	allowed bool
+	reason  string
+	err     error
+	got     *authorizationv1.SubjectAccessReview
+}
+
+func (f *fakeReviewer) Create(_ context.Context, sar *authorizationv1.SubjectAccessReview, _ metav1.CreateOptions) (*authorizationv1.SubjectAccessReview, error) {
+	f.got = sar
+	if f.err != nil {
+		return nil, f.err
+	}
+	out := sar.DeepCopy()
+	out.Status = authorizationv1.SubjectAccessReviewStatus{Allowed: f.allowed, Reason: f.reason}
+	return out, nil
+}
+
+func runWithServiceAccount(name string) *ottoflowv1alpha1.WorkflowRun {
+	run := &ottoflowv1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "run-1"},
+		Spec: ottoflowv1alpha1.WorkflowRunSpec{
+			WorkflowRef: ottoflowv1alpha1.WorkflowRef{Name: "wf"},
+		},
+	}
+	if name != "" {
+		run.Spec.Execution = &ottoflowv1alpha1.WorkflowRunExecutionSpec{
+			Job: &ottoflowv1alpha1.WorkflowRunJobSpec{ServiceAccountName: name},
+		}
+	}
+	return run
+}
+
+func requestContext(groups ...string) context.Context {
+	return admission.NewContextWithRequest(context.Background(), admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			UserInfo: authenticationv1.UserInfo{
+				Username: "alice",
+				UID:      "uid-1",
+				Groups:   groups,
+				Extra:    map[string]authenticationv1.ExtraValue{"scopes": {"a", "b"}},
+			},
+		},
+	})
+}
+
+// Naming a ServiceAccount is an escalation unless the submitter is allowed to
+// run as it: the runner Job is launched with that account's token.
+func TestRunnerServiceAccountRequiresAuthorization(t *testing.T) {
+	reviewer := &fakeReviewer{allowed: false, reason: "no binding"}
+	v := &WorkflowRunValidator{Authorizer: reviewer}
+
+	_, err := v.ValidateCreate(requestContext(), runWithServiceAccount("privileged-sa"))
+	if err == nil {
+		t.Fatal("run naming an unauthorized ServiceAccount was admitted")
+	}
+	for _, want := range []string{"alice", "privileged-sa", "team-a", "no binding"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not name %q", err, want)
+		}
+	}
+}
+
+func TestRunnerServiceAccountAllowedWhenAuthorized(t *testing.T) {
+	reviewer := &fakeReviewer{allowed: true}
+	v := &WorkflowRunValidator{Authorizer: reviewer}
+
+	if _, err := v.ValidateCreate(requestContext("builders"), runWithServiceAccount("build-runner")); err != nil {
+		t.Fatalf("authorized run rejected: %v", err)
+	}
+
+	spec := reviewer.got.Spec
+	if spec.User != "alice" || spec.UID != "uid-1" {
+		t.Errorf("review asked about %q/%q, want alice/uid-1", spec.User, spec.UID)
+	}
+	if len(spec.Groups) != 1 || spec.Groups[0] != "builders" {
+		t.Errorf("review groups = %v, want [builders]", spec.Groups)
+	}
+	if len(spec.Extra["scopes"]) != 2 {
+		t.Errorf("review extra = %v, want the submitter's extra carried through", spec.Extra)
+	}
+	attrs := spec.ResourceAttributes
+	if attrs == nil {
+		t.Fatal("review carried no resource attributes")
+	}
+	if attrs.Verb != UseVerb || attrs.Resource != "serviceaccounts" ||
+		attrs.Name != "build-runner" || attrs.Namespace != "team-a" {
+		t.Errorf("review asked for %+v, want use serviceaccounts/build-runner in team-a", attrs)
+	}
+}
+
+// A run that names no ServiceAccount gets the least-privilege default, so
+// there is nothing to authorize and no review to spend.
+func TestNoServiceAccountNoReview(t *testing.T) {
+	reviewer := &fakeReviewer{allowed: false}
+	v := &WorkflowRunValidator{Authorizer: reviewer}
+
+	if _, err := v.ValidateCreate(requestContext(), runWithServiceAccount("")); err != nil {
+		t.Fatalf("run without a ServiceAccount rejected: %v", err)
+	}
+	if reviewer.got != nil {
+		t.Error("a review was issued for a run that names no ServiceAccount")
+	}
+}
+
+// The field is mutable, so authorizing only creates would let a run be
+// submitted clean and then patched.
+func TestRunnerServiceAccountCheckedOnUpdate(t *testing.T) {
+	v := &WorkflowRunValidator{Authorizer: &fakeReviewer{allowed: false}}
+
+	_, err := v.ValidateUpdate(requestContext(), runWithServiceAccount(""), runWithServiceAccount("privileged-sa"))
+	if err == nil {
+		t.Fatal("a run patched to name an unauthorized ServiceAccount was admitted")
+	}
+}
+
+// Anything that stops the check from reaching a verdict is a rejection, not a
+// pass: admitting on a failed review would make the check decoration.
+func TestRunnerServiceAccountFailsClosed(t *testing.T) {
+	tests := []struct {
+		name string
+		v    *WorkflowRunValidator
+		ctx  context.Context
+		want string
+	}{
+		{
+			name: "review errors",
+			v:    &WorkflowRunValidator{Authorizer: &fakeReviewer{err: errors.New("apiserver down")}},
+			ctx:  requestContext(),
+			want: "apiserver down",
+		},
+		{
+			name: "no authorizer wired",
+			v:    &WorkflowRunValidator{},
+			ctx:  requestContext(),
+			want: "cannot authorize",
+		},
+		{
+			name: "request carries no user",
+			v:    &WorkflowRunValidator{Authorizer: &fakeReviewer{allowed: true}},
+			ctx:  context.Background(),
+			want: "no user to authorize",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := tc.v.ValidateCreate(tc.ctx, runWithServiceAccount("privileged-sa"))
+			if err == nil {
+				t.Fatal("run was admitted despite the check not reaching a verdict")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error = %q, want it to contain %q", err, tc.want)
+			}
+		})
+	}
+}

--- a/internal/webhook/workflow_validator.go
+++ b/internal/webhook/workflow_validator.go
@@ -24,6 +24,10 @@ import (
 // WorkflowValidator validates Workflow resources at admission time.
 type WorkflowValidator struct {
 	Client client.Client
+	// Authorizer decides whether the author may run workflows as the
+	// ServiceAccount this Workflow declares. A nil Authorizer rejects every
+	// Workflow that declares one.
+	Authorizer SubjectAccessReviewer
 }
 
 // ValidateCreate implements admission.Validator.
@@ -42,7 +46,13 @@ func (v *WorkflowValidator) ValidateDelete(ctx context.Context, w *ottoflowv1alp
 }
 
 func (v *WorkflowValidator) validate(ctx context.Context, w *ottoflowv1alpha1.Workflow) (admission.Warnings, error) {
-	if w == nil || len(w.Spec.Steps) == 0 {
+	if w == nil {
+		return nil, nil
+	}
+	if err := v.authorizeWorkflowServiceAccount(ctx, w); err != nil {
+		return nil, err
+	}
+	if len(w.Spec.Steps) == 0 {
 		return nil, nil
 	}
 	if _, err := executor.BuildDAG(w.Spec.Steps); err != nil {

--- a/internal/webhook/workflowrun_validator.go
+++ b/internal/webhook/workflowrun_validator.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"fmt"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	ottoflowv1alpha1 "github.com/nirmata/ottoflow/api/v1alpha1"
@@ -21,6 +22,9 @@ type WorkflowRunValidator struct {
 	// Authorizer decides whether the submitter may run as the ServiceAccount a
 	// run names. A nil Authorizer rejects every run that names one.
 	Authorizer SubjectAccessReviewer
+	// Client reads the run's Workflow, to tell a run that inherited its
+	// ServiceAccount from one that chose it.
+	Client client.Client
 }
 
 // ValidateCreate implements admission.Validator.

--- a/internal/webhook/workflowrun_validator.go
+++ b/internal/webhook/workflowrun_validator.go
@@ -17,16 +17,22 @@ import (
 )
 
 // WorkflowRunValidator validates WorkflowRun resources at admission time.
-type WorkflowRunValidator struct{}
+type WorkflowRunValidator struct {
+	// Authorizer decides whether the submitter may run as the ServiceAccount a
+	// run names. A nil Authorizer rejects every run that names one.
+	Authorizer SubjectAccessReviewer
+}
 
 // ValidateCreate implements admission.Validator.
 func (v *WorkflowRunValidator) ValidateCreate(ctx context.Context, run *ottoflowv1alpha1.WorkflowRun) (admission.Warnings, error) {
-	return v.validate(run)
+	return v.validate(ctx, run)
 }
 
 // ValidateUpdate implements admission.Validator.
 func (v *WorkflowRunValidator) ValidateUpdate(ctx context.Context, oldRun, run *ottoflowv1alpha1.WorkflowRun) (admission.Warnings, error) {
-	return v.validate(run)
+	// Checked on update too: the field is mutable, so authorizing only creates
+	// would let a run be submitted with no ServiceAccount and then patched.
+	return v.validate(ctx, run)
 }
 
 // ValidateDelete implements admission.Validator.
@@ -34,7 +40,7 @@ func (v *WorkflowRunValidator) ValidateDelete(ctx context.Context, run *ottoflow
 	return nil, nil
 }
 
-func (v *WorkflowRunValidator) validate(run *ottoflowv1alpha1.WorkflowRun) (admission.Warnings, error) {
+func (v *WorkflowRunValidator) validate(ctx context.Context, run *ottoflowv1alpha1.WorkflowRun) (admission.Warnings, error) {
 	if run == nil {
 		return nil, nil
 	}
@@ -49,6 +55,9 @@ func (v *WorkflowRunValidator) validate(run *ottoflowv1alpha1.WorkflowRun) (admi
 		if ref.Namespace != "" && ref.Namespace != run.Namespace {
 			return nil, fmt.Errorf("WorkflowRun %q spec.execution.llmCredentialsSecret.namespace must be empty or match the WorkflowRun namespace %q; cross-namespace Secret references are not supported because SecretKeyRef is namespace-scoped to the runner pod", run.Name, run.Namespace)
 		}
+	}
+	if err := v.authorizeRunnerServiceAccount(ctx, run); err != nil {
+		return nil, err
 	}
 	return nil, nil
 }


### PR DESCRIPTION
Closes #26.

A WorkflowRun can set `spec.execution.job.serviceAccountName` to any account in its namespace, `buildWorkflowRunnerJob` honours it, and `ensureRunnerAccess` skips runs that name one. The Job then runs with that account's token — so anyone who can create a WorkflowRun can pick a privileged ServiceAccount and get its credentials, which is the escalation scoping the runner to its own role set out to close.

The account is chosen in two places, and each is now authorized where the choice is made:

- `Workflow.spec.execution.job.serviceAccountName` — against the Workflow author, at Workflow admission.
- `WorkflowRun.spec.execution.job.serviceAccountName` — against whoever submitted the run.

Either way the check is a `SubjectAccessReview` for `use` on that ServiceAccount in that namespace, and the object is rejected if the answer is no:

```text
WorkflowRun "nightly": "system:serviceaccount:team-a:submitter" may not use
serviceaccount "privileged-sa" in namespace "team-a"
```

Operators grant it by naming the accounts a subject may borrow:

```yaml
rules:
  - apiGroups: [""]
    resources: ["serviceaccounts"]
    resourceNames: ["build-runner"]
    verbs: ["use"]
```

## Smaller than the issue expected

The issue says the validator would have to become a raw admission handler, since it does not receive `UserInfo`. It does not — controller-runtime puts the `AdmissionRequest` into the context before calling the validator (`admission/validator_custom.go:104`), so `admission.RequestFromContext` reaches the user without changing the handler shape. The change is one new file plus a field on the validator.

A run whose account matches the one its Workflow declares is inheriting rather than choosing, so it is not reviewed again — this is what keeps cron runs working, since the scheduler copies `spec.execution` into every run it creates and creates it as the controller. Same namespace only: the account is used in the run's namespace, and a Workflow elsewhere was authorized against its own. A run naming an account its Workflow does not declare is still reviewed.

Two other things worth noting:

- Checked on **update** as well as create. The field is mutable, so authorizing only creates would let a run be submitted clean and then patched.
- Everything that stops the check reaching a verdict **rejects**: a review that errors, a request carrying no user, a validator with no authorizer wired. A check that admits when it cannot decide is not a check.

`subjectaccessreviews` create moves out of the MCP fragment — which only renders when the MCP server is enabled — into the core controller role, since the webhook needs it whenever it runs.

## Breaking

Anyone already setting `serviceAccountName` has their runs rejected until someone grants `use` on that account. That is the point of the fix, but it is a real migration step and worth a release note. Say if you would rather have a flag for a transition period; I left one out deliberately, since a switch that turns off an authorization check tends to stay on.

## Verified

Against a real API server, that the grant behaves as designed:

```text
granted SA:      yes
un-granted SA:   no
unrelated user:  no
```

Unit tests cover the review contents (user, UID, groups, extra, and the resource attributes), the allow and deny paths on both objects, update, no-review-when-unset, the three fail-closed cases, and inheritance: admitted with no review issued, still reviewed when the account differs, and not honoured across namespaces.

`make build`, `make verify-codegen`, `go test`, `helm lint`, chart RBAC tests pass.
