### PR TITLE
docs: correct per-step ServiceAccount proposal status

### DIFF
--- a/docs/dev/PROPOSAL_PER_STEP_SA.md
+++ b/docs/dev/PROPOSAL_PER_STEP_SA.md
@@ -51,7 +51,7 @@ immediately. Full identity isolation: all Kubernetes calls within the step, incl
 macros, use the per-step SA.  
 **Cons**: Requires adding `targetRESTConfig *rest.Config` to `WorkflowExecutor` so the minted
 bearer token can be used to construct a new scoped `client.Client`.  
-**Decision**: Implemented (see below).
+**Decision**: Recommended — not yet implemented (design below).
 
 ---
 


### PR DESCRIPTION
## What

Corrects `docs/dev/PROPOSAL_PER_STEP_SA.md`: the per-step ServiceAccount design was marked `Decision: Implemented`, but no implementing code exists.

## Why

Verified absent in the current tree — no `internal/workflow/executor/step_identity.go`, no `ServiceAccountRef` / `DefaultServiceAccount` API fields, no `serviceaccounts/token` RBAC rule, and no `TokenRequest` / token-minting code. A public design doc marking an unbuilt security control as "Implemented" is misleading. This flips that one line to "Recommended — not yet implemented (design below)"; the top-level `Status: Draft` was already correct.

## Scope

One-line documentation correction. No code changes.
