### PR TITLE
fix: describe every chart value in the schema, and drop the two that do nothing

### DIFF
--- a/charts/ottoflow/README.md
+++ b/charts/ottoflow/README.md
@@ -280,8 +280,6 @@ helm upgrade ottoflow ./charts/ottoflow -n ottoflow --set webhook.enabled=false
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `crds.install` | Install CRDs | `true` |
-| `crds.mode` | CRD installation mode | `install` |
 
 ### Namespace Parameters
 
@@ -378,10 +376,8 @@ networkPolicy:
 
 ### Skip CRD Installation
 
-```yaml
-crds:
-  install: false
-  mode: skip
+```bash
+helm install ottoflow ./charts/ottoflow --skip-crds
 ```
 
 ## Upgrading
@@ -501,12 +497,11 @@ make sync-crds
 
 ### Skip CRD Installation
 
-If CRDs are managed separately (e.g., via GitOps or another tool), you can skip CRD installation:
+If CRDs are managed separately (e.g., via GitOps or another tool), skip them with
+Helm's own flag:
 
-```yaml
-crds:
-  install: false
-  mode: skip
+```bash
+helm install ottoflow ./charts/ottoflow --skip-crds
 ```
 
 ### Manual CRD Installation
@@ -520,10 +515,14 @@ kubectl apply -f config/crd/bases/
 # Or from chart (after syncing)
 kubectl apply -f charts/ottoflow/crds/
 
-# Then install chart with CRDs disabled
+# Then install the chart without them
 helm install ottoflow ./charts/ottoflow --namespace ottoflow --create-namespace \
-  --set crds.install=false
+  --skip-crds
 ```
+
+CRDs live in `crds/`, which Helm installs before any template and does not
+template itself, so no chart value can gate them. `--skip-crds` is Helm's own
+flag and the only way to skip them.
 
 ## Uninstallation
 

--- a/charts/ottoflow/templates/crds-install-notes.yaml
+++ b/charts/ottoflow/templates/crds-install-notes.yaml
@@ -1,9 +1,0 @@
-{{- if .Values.crds.install }}
-{{- if eq .Values.crds.mode "install" }}
----
-# Note: CRDs are installed from the crds/ directory
-# CRDs in the crds/ directory are installed before any templates
-# They are not upgraded by Helm - manual upgrade may be required
-# To skip CRD installation, set crds.install: false or crds.mode: skip
-{{- end }}
-{{- end }}

--- a/charts/ottoflow/values.schema.json
+++ b/charts/ottoflow/values.schema.json
@@ -1,155 +1,632 @@
 {
   "$schema": "http://json-schema.org/schema#",
+  "title": "OttoFlow Helm values",
+  "description": "Every key the chart reads. additionalProperties is false wherever the key set is the chart's own, so a value set at a path no template reads fails the install instead of doing nothing.",
   "type": "object",
+  "additionalProperties": false,
   "properties": {
-    "global": {
+    "agentExecutor": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
-        "imageRegistry": {
-          "type": "string",
-          "description": "Global Docker image registry"
+        "affinity": {
+          "type": "object"
         },
-        "imagePullPolicy": {
-          "type": "string",
-          "enum": ["Always", "IfNotPresent", "Never"],
-          "description": "Global image pull policy"
+        "args": {
+          "type": "array"
         },
-        "imagePullSecrets": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Global image pull secrets"
-        }
-      }
-    },
-    "controller": {
-      "type": "object",
-      "properties": {
+        "callerNamespace": {
+          "type": [
+            "string",
+            "integer",
+            "boolean"
+          ]
+        },
+        "command": {
+          "type": "array"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "env": {
+          "type": "array"
+        },
+        "fullnameOverride": {
+          "type": [
+            "string",
+            "integer",
+            "boolean"
+          ]
+        },
+        "goMemLimit": {
+          "type": "string"
+        },
         "image": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
+            "fullOverride": {
+              "type": [
+                "string",
+                "integer",
+                "boolean"
+              ]
+            },
             "registry": {
-              "type": "string",
-              "description": "Controller image registry"
+              "type": "string"
             },
             "repository": {
-              "type": "string",
-              "description": "Controller image repository"
+              "type": "string"
             },
             "tag": {
-              "type": "string",
-              "description": "Controller image tag"
-            },
-            "fullOverride": {
-              "type": "string",
-              "description": "Override full image name"
+              "type": [
+                "string",
+                "integer",
+                "boolean"
+              ]
             }
           }
         },
+        "livenessProbe": {
+          "type": "object"
+        },
+        "llmCredentialsSecret": {
+          "type": [
+            "string",
+            "integer",
+            "boolean"
+          ]
+        },
+        "nameOverride": {
+          "type": [
+            "string",
+            "integer",
+            "boolean"
+          ]
+        },
+        "nodeSelector": {
+          "type": "object"
+        },
+        "podAnnotations": {
+          "type": "object"
+        },
+        "podLabels": {
+          "type": "object"
+        },
+        "podSecurityContext": {
+          "type": "object"
+        },
+        "readinessProbe": {
+          "type": "object"
+        },
         "replicaCount": {
-          "type": "integer",
-          "minimum": 1,
-          "description": "Number of controller replicas"
+          "type": "integer"
+        },
+        "resources": {
+          "type": "object"
+        },
+        "securityContext": {
+          "type": "object"
+        },
+        "service": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "port": {
+              "type": "integer"
+            },
+            "type": {
+              "type": "string"
+            }
+          }
         },
         "serviceAccount": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
+            "annotations": {
+              "type": "object"
+            },
             "create": {
-              "type": "boolean",
-              "description": "Create service account"
+              "type": "boolean"
             },
             "name": {
-              "type": "string",
-              "description": "Service account name"
-            },
-            "annotations": {
-              "type": "object",
-              "description": "Service account annotations"
+              "type": [
+                "string",
+                "integer",
+                "boolean"
+              ]
             }
           }
+        },
+        "terminationGracePeriodSeconds": {
+          "type": "integer"
+        },
+        "tls": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "internal": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "secretName": {
+              "type": [
+                "string",
+                "integer",
+                "boolean"
+              ]
+            }
+          }
+        },
+        "tolerations": {
+          "type": "array"
+        }
+      }
+    },
+    "commonAnnotations": {
+      "type": "object"
+    },
+    "commonLabels": {
+      "type": "object"
+    },
+    "controller": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "affinity": {
+          "type": "object"
+        },
+        "args": {
+          "type": "array"
+        },
+        "command": {
+          "type": "array"
+        },
+        "env": {
+          "type": "array"
+        },
+        "fullnameOverride": {
+          "type": [
+            "string",
+            "integer",
+            "boolean"
+          ]
+        },
+        "image": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "fullOverride": {
+              "type": [
+                "string",
+                "integer",
+                "boolean"
+              ]
+            },
+            "nameOverride": {
+              "type": [
+                "string",
+                "integer",
+                "boolean"
+              ]
+            },
+            "registry": {
+              "type": "string"
+            },
+            "repository": {
+              "type": "string"
+            },
+            "tag": {
+              "type": [
+                "string",
+                "integer",
+                "boolean"
+              ]
+            }
+          }
+        },
+        "livenessProbe": {
+          "type": "object"
+        },
+        "mcp": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "addr": {
+              "type": "string"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "service": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "port": {
+                  "type": "integer"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "metrics": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "port": {
+              "type": "integer"
+            },
+            "serviceMonitor": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "interval": {
+                  "type": "string"
+                },
+                "labels": {
+                  "type": "object"
+                },
+                "scrapeTimeout": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "nameOverride": {
+          "type": [
+            "string",
+            "integer",
+            "boolean"
+          ]
+        },
+        "namespace": {
+          "type": [
+            "string",
+            "integer",
+            "boolean"
+          ]
+        },
+        "nodeSelector": {
+          "type": "object"
+        },
+        "podAnnotations": {
+          "type": "object"
+        },
+        "podLabels": {
+          "type": "object"
+        },
+        "podSecurityContext": {
+          "type": "object"
+        },
+        "prometheusURL": {
+          "type": [
+            "string",
+            "integer",
+            "boolean"
+          ]
+        },
+        "readinessProbe": {
+          "type": "object"
+        },
+        "replicaCount": {
+          "type": "integer"
         },
         "resources": {
+          "type": "object"
+        },
+        "securityContext": {
+          "type": "object"
+        },
+        "serviceAccount": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
-            "limits": {
-              "type": "object",
-              "properties": {
-                "cpu": {
-                  "type": "string"
-                },
-                "memory": {
-                  "type": "string"
-                }
-              }
+            "annotations": {
+              "type": "object"
             },
-            "requests": {
+            "create": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": [
+                "string",
+                "integer",
+                "boolean"
+              ]
+            }
+          }
+        },
+        "terminationGracePeriodSeconds": {
+          "type": "integer"
+        },
+        "tolerations": {
+          "type": "array"
+        },
+        "webhookTrigger": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "addr": {
+              "type": "string"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "service": {
               "type": "object",
+              "additionalProperties": false,
               "properties": {
-                "cpu": {
-                  "type": "string"
+                "enabled": {
+                  "type": "boolean"
                 },
-                "memory": {
+                "port": {
+                  "type": "integer"
+                },
+                "type": {
                   "type": "string"
                 }
               }
             }
           }
         }
-      },
-      "required": ["image"]
-    },
-    "rbac": {
-      "type": "object",
-      "properties": {
-        "create": {
-          "type": "boolean",
-          "description": "Create RBAC resources"
-        },
-        "leaderElection": {
-          "type": "object",
-          "properties": {
-            "create": {
-              "type": "boolean",
-              "description": "Create leader election RBAC"
-            }
-          }
-        }
       }
     },
-    "networkPolicy": {
+    "global": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
-        "create": {
-          "type": "boolean",
-          "description": "Create NetworkPolicy"
-        }
-      }
-    },
-    "crds": {
-      "type": "object",
-      "properties": {
-        "install": {
-          "type": "boolean",
-          "description": "Install CRDs"
+        "imagePullPolicy": {
+          "type": "string"
         },
-        "mode": {
-          "type": "string",
-          "enum": ["install", "skip"],
-          "description": "CRD installation mode"
+        "imagePullSecrets": {
+          "type": "array"
+        },
+        "imageRegistry": {
+          "type": "string"
         }
       }
     },
     "namespace": {
       "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": [
+            "string",
+            "integer",
+            "boolean"
+          ]
+        }
+      }
+    },
+    "networkPolicy": {
+      "type": "object",
+      "additionalProperties": false,
       "properties": {
         "create": {
-          "type": "boolean",
-          "description": "Create namespace"
+          "type": "boolean"
         },
-        "name": {
-          "type": "string",
-          "description": "Namespace name"
+        "egress": {
+          "type": "array"
+        }
+      }
+    },
+    "rbac": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "clusterRole": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "extraResources": {
+              "type": "array"
+            }
+          }
+        },
+        "coreClusterRole": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "extraResources": {
+              "type": "array"
+            }
+          }
+        },
+        "create": {
+          "type": "boolean"
+        },
+        "leaderElection": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "create": {
+              "type": "boolean"
+            }
+          }
+        },
+        "runnerClusterRole": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "extraResources": {
+              "type": "array"
+            }
+          }
+        },
+        "viewClusterRole": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "extraResources": {
+              "type": "array"
+            }
+          }
+        }
+      }
+    },
+    "serveA2A": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "clusterRole": {
+          "type": [
+            "string",
+            "integer",
+            "boolean"
+          ]
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "image": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "fullOverride": {
+              "type": [
+                "string",
+                "integer",
+                "boolean"
+              ]
+            },
+            "registry": {
+              "type": "string"
+            },
+            "repository": {
+              "type": "string"
+            },
+            "tag": {
+              "type": [
+                "string",
+                "integer",
+                "boolean"
+              ]
+            }
+          }
+        },
+        "serviceAccountName": {
+          "type": "string"
+        }
+      }
+    },
+    "webhook": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "annotations": {
+          "type": "object"
+        },
+        "caBundle": {
+          "type": [
+            "string",
+            "integer",
+            "boolean"
+          ]
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "failurePolicy": {
+          "type": "string"
+        },
+        "timeoutSeconds": {
+          "type": "integer"
+        }
+      }
+    },
+    "workflowRunner": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "agentExecutorCASecret": {
+          "type": [
+            "string",
+            "integer",
+            "boolean"
+          ]
+        },
+        "clusterRole": {
+          "type": [
+            "string",
+            "integer",
+            "boolean"
+          ]
+        },
+        "image": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "fullOverride": {
+              "type": [
+                "string",
+                "integer",
+                "boolean"
+              ]
+            },
+            "registry": {
+              "type": "string"
+            },
+            "repository": {
+              "type": "string"
+            },
+            "tag": {
+              "type": [
+                "string",
+                "integer",
+                "boolean"
+              ]
+            }
+          }
+        },
+        "imagePullPolicy": {
+          "type": "string"
+        },
+        "imagePullSecrets": {
+          "type": "array"
+        },
+        "llmCredentialsSecret": {
+          "type": [
+            "string",
+            "integer",
+            "boolean"
+          ]
+        },
+        "podLabelsPartOf": {
+          "type": [
+            "string",
+            "integer",
+            "boolean"
+          ]
+        },
+        "serviceAccountName": {
+          "type": [
+            "string",
+            "integer",
+            "boolean"
+          ]
+        },
+        "ttlSecondsAfterFinished": {
+          "type": "integer"
         }
       }
     }

--- a/charts/ottoflow/values.yaml
+++ b/charts/ottoflow/values.yaml
@@ -508,14 +508,6 @@ networkPolicy:
       - protocol: TCP
         port: 4317
 
-# CRD installation
-crds:
-  # Specifies whether CRDs should be installed
-  install: true
-  # CRD installation mode: "install" (default) or "skip"
-  # Use "skip" if CRDs are managed outside of Helm
-  mode: install
-
 # Namespace configuration
 namespace:
   # Namespace name (if not set, uses Release.Namespace from helm -n)
@@ -526,4 +518,3 @@ commonLabels: {}
 commonAnnotations: {}
 
 # Additional resources (for advanced users)
-additionalResources: []

--- a/test/chart/values_schema_test.go
+++ b/test/chart/values_schema_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2026 Nirmata, Inc.
+
+Use of this source code is governed by the Business Source License 1.1
+that can be found in the LICENSE.md file.
+*/
+
+package chart
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"sigs.k8s.io/yaml"
+)
+
+// readValues loads values.yaml as a generic map.
+func readValues(t *testing.T) map[string]any {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(chartDir(t), "values.yaml"))
+	if err != nil {
+		t.Fatalf("reading values.yaml: %v", err)
+	}
+	var values map[string]any
+	if err := yaml.Unmarshal(raw, &values); err != nil {
+		t.Fatalf("parsing values.yaml: %v", err)
+	}
+	return values
+}
+
+// readSchema loads values.schema.json.
+func readSchema(t *testing.T) map[string]any {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(chartDir(t), "values.schema.json"))
+	if err != nil {
+		t.Fatalf("reading values.schema.json: %v", err)
+	}
+	var schema map[string]any
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		t.Fatalf("parsing values.schema.json: %v", err)
+	}
+	return schema
+}
+
+// TestSchemaDescribesEveryValue fails when a key is added to values.yaml and
+// not to the schema. With additionalProperties false, that combination makes
+// the chart refuse its own defaults, so it has to be caught here rather than at
+// someone's install.
+func TestSchemaDescribesEveryValue(t *testing.T) {
+	missing := diffKeys(readValues(t), properties(readSchema(t)), "")
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		t.Errorf("values.yaml keys absent from values.schema.json: %v", missing)
+	}
+}
+
+// TestSchemaDescribesNothingExtra fails when the schema keeps describing a
+// value that values.yaml no longer declares. A key documented in the schema
+// and set by nobody is the shape dead values take once they are removed.
+func TestSchemaDescribesNothingExtra(t *testing.T) {
+	extra := diffKeys(properties(readSchema(t)), readValues(t), "")
+	if len(extra) > 0 {
+		sort.Strings(extra)
+		t.Errorf("values.schema.json keys absent from values.yaml: %v", extra)
+	}
+}
+
+// TestSchemaIsClosed asserts the top level rejects unknown keys. Without it a
+// value set at a path no template reads is accepted and silently ignored,
+// which is how metrics ended up nested under webhook.
+func TestSchemaIsClosed(t *testing.T) {
+	schema := readSchema(t)
+	if closed, _ := schema["additionalProperties"].(bool); closed {
+		t.Error("values.schema.json allows additional top-level properties")
+	}
+	if _, ok := schema["additionalProperties"]; !ok {
+		t.Error("values.schema.json does not set additionalProperties at the top level")
+	}
+}
+
+// properties reduces a schema node to the value shape its properties describe,
+// so the two trees can be walked together. Nodes that deliberately accept
+// arbitrary keys (Kubernetes passthrough like resources or nodeSelector)
+// declare no properties and compare as leaves.
+func properties(node map[string]any) map[string]any {
+	props, ok := node["properties"].(map[string]any)
+	if !ok {
+		return map[string]any{}
+	}
+	out := make(map[string]any, len(props))
+	for name, raw := range props {
+		child, ok := raw.(map[string]any)
+		if !ok {
+			out[name] = nil
+			continue
+		}
+		if nested := properties(child); len(nested) > 0 {
+			out[name] = nested
+			continue
+		}
+		out[name] = nil
+	}
+	return out
+}
+
+// diffKeys returns the paths present in want and absent from got.
+func diffKeys(want, got map[string]any, prefix string) []string {
+	var missing []string
+	for name, value := range want {
+		path := name
+		if prefix != "" {
+			path = prefix + "." + name
+		}
+		other, present := got[name]
+		if !present {
+			missing = append(missing, path)
+			continue
+		}
+		wantChild, wantNested := value.(map[string]any)
+		gotChild, gotNested := other.(map[string]any)
+		if wantNested && gotNested {
+			missing = append(missing, diffKeys(wantChild, gotChild, path)...)
+		}
+	}
+	return missing
+}


### PR DESCRIPTION
Closes the `values.schema.json` and dead-values items in #15.

`values.schema.json` described 6 of the 13 top-level keys and set `additionalProperties` nowhere, so a value set at a path no template reads was accepted and ignored. That is how `metrics` and `prometheusURL` sat under `webhook:` while the templates read `controller.*` (#9): the install was happy either way.

The schema now covers every key the chart reads and closes each level whose keys are the chart's own. Blocks handed to Kubernetes verbatim — `resources`, `securityContext`, `nodeSelector`, `tolerations`, probes, `env`, `args`, `extraRules` — stay open, since users legitimately set keys the defaults do not show.

It catches the original bug and ordinary typos:

```console
$ helm template ottoflow charts/ottoflow --set webhook.metrics.enabled=true
Error: at '/webhook': additional properties 'metrics' not allowed

$ helm template ottoflow charts/ottoflow --set controller.replicaCounts=3
Error: at '/controller': additional properties 'replicaCounts' not allowed
```

## Two values removed rather than described

Neither did anything.

`crds.install` / `crds.mode` gated one template that renders a **YAML comment**. CRDs live in `crds/`, which Helm installs before any template and does not template, so no chart value can gate them. The README documented both keys and offered `--set crds.install=false` as the way to manage CRDs externally — which installed them anyway. It now points at `--skip-crds`, Helm's own flag and the only thing that works.

`additionalResources` appeared in `values.yaml` and nowhere else in the repo.

## Keeping it honest

Three tests in `test/chart`:

- every values.yaml key is described by the schema
- the schema describes nothing values.yaml does not declare
- the top level is closed

The first matters most: with `additionalProperties: false`, a key added to `values.yaml` and not the schema makes the chart reject its own defaults. Verified it fails on exactly that — adding a `newFeature` key to values.yaml alone gives `values.yaml keys absent from values.schema.json: [newFeature]`.

`make build`, `go test`, `helm lint`, `helm template` pass.
